### PR TITLE
feat: include inactive records in admin consultar lists

### DIFF
--- a/src/app/pages/consultar-categorias/consultar-categorias.component.ts
+++ b/src/app/pages/consultar-categorias/consultar-categorias.component.ts
@@ -33,7 +33,7 @@ export class ConsultarCategoriasComponent implements OnInit {
   }
 
   listCategorias() {
-    this.service.list(0, 100).subscribe({
+    this.service.list(0, 100, true).subscribe({
       next: (response: any) => {
         console.log('response:', response)
         console.log('primer item:', response[0])

--- a/src/app/pages/consultar-locales/consultar-locales.component.ts
+++ b/src/app/pages/consultar-locales/consultar-locales.component.ts
@@ -33,7 +33,7 @@ export class ConsultarLocalesComponent implements OnInit {
 
   listLocales() {
     const entidadInfo = JSON.parse(localStorage.getItem('entidadInfo') || '{}')
-    this.localService.list(entidadInfo.id).subscribe({
+    this.localService.list(entidadInfo.id, true).subscribe({
       next: (response: any) => {
         this.locales = response.data.map((l: any) => ({
           ...l,

--- a/src/app/pages/consultar-vecinos/consultar-vecinos.component.ts
+++ b/src/app/pages/consultar-vecinos/consultar-vecinos.component.ts
@@ -33,7 +33,7 @@ export class ConsultarVecinosComponent implements OnInit {
 
   listVecinos() {
     const entidadInfo = JSON.parse(localStorage.getItem('entidadInfo') || '{}')
-    this.vecinoService.list(entidadInfo.id).subscribe({
+    this.vecinoService.list(entidadInfo.id, true).subscribe({
       next: (response: any) => {
         this.vecinos = response.data.map((v: any) => ({
           ...v,

--- a/src/app/services/local-adherido/local-adherido.service.ts
+++ b/src/app/services/local-adherido/local-adherido.service.ts
@@ -114,8 +114,11 @@ export class LocalAdheridoService {
     return this.http.put<any>(this.urlCoupon + '/' + id, { isAvailable: false, state: 'DISABLED' })
   }
 
-  list(entityId?: string): Observable<any> {
-    const params = entityId ? `?entityId=${entityId}` : ''
+  list(entityId?: string, includeInactive = false): Observable<any> {
+    const query = new URLSearchParams()
+    if (entityId) query.set('entityId', entityId)
+    if (includeInactive) query.set('includeInactive', 'true')
+    const params = query.toString() ? `?${query.toString()}` : ''
     return this.http.get<any>(`${this.url}${params}`)
   }
 }

--- a/src/app/services/vecino/vecino.service.ts
+++ b/src/app/services/vecino/vecino.service.ts
@@ -51,10 +51,13 @@ export class VecinoService {
     return this.http.get<any>(`http://localhost:8080/api/coupon-transaction/neighbor/${neighborId}`)
   }
 
-  list(entityId?: string): Observable<any> {
+  list(entityId?: string, includeInactive = false): Observable<any> {
     const token = localStorage.getItem('accessToken')
     const headers = new HttpHeaders({ Authorization: `Bearer ${token}` })
-    const params = entityId ? `?entityId=${entityId}` : ''
+    const query = new URLSearchParams()
+    if (entityId) query.set('entityId', entityId)
+    if (includeInactive) query.set('includeInactive', 'true')
+    const params = query.toString() ? `?${query.toString()}` : ''
     return this.http.get<any>(`${this.url}${params}`, { headers })
   }
 

--- a/src/app/services/wasteCategory/waste-category.service.ts
+++ b/src/app/services/wasteCategory/waste-category.service.ts
@@ -13,10 +13,11 @@ export class WasteCategoryService {
   private url: string = 'http://localhost:8080/api/waste-category'
 
   constructor() {}
-  list(offset: number, limit: number): Observable<WasteCategory[]> {
-    return this.http.get<WasteCategory[]>(`${this.url}?offset=${offset}&limit=${limit}`).pipe(
+  list(offset: number, limit: number, includeInactive = false): Observable<WasteCategory[]> {
+    let params = `?offset=${offset}&limit=${limit}`
+    if (includeInactive) params += `&includeInactive=true`
+    return this.http.get<WasteCategory[]>(`${this.url}${params}`).pipe(
       map((resp: any) => {
-        console.log(resp.data)
         return resp.data
       })
     )


### PR DESCRIPTION
- add includeInactive opt-in param to vecino, wasteCategory and local-adherido list services
- pass includeInactive=true from consultar-vecinos, consultar-categorias and consultar-locales
- remove leftover console.log in waste-category service