### PR TITLE
fix: move hardcoded api keys to runtime env vars

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -24,8 +24,9 @@ export function app(): express.Express {
     maxAge: '1y'
   }));
 
-  // Public backend host, resolved at runtime (set API_URL in Railway).
   const apiUrl = process.env['API_URL'] || 'http://localhost:8080';
+  const recaptchaSiteKey = process.env['RECAPTCHA_SITE_KEY'] || '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+  const googleMapsApiKey = process.env['GOOGLE_MAPS_API_KEY'] || '';
 
   // All regular routes use the Angular engine
   server.get('*', (req, res, next) => {
@@ -40,11 +41,10 @@ export function app(): express.Express {
         providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
       })
       .then((html) =>
-        // Expose the API host to the browser bundle before it bootstraps.
         res.send(
           html.replace(
             '</head>',
-            `<script>window.__API_URL__=${JSON.stringify(apiUrl)}</script></head>`
+            `<script>window.__API_URL__=${JSON.stringify(apiUrl)};window.__RECAPTCHA_SITE_KEY__=${JSON.stringify(recaptchaSiteKey)}</script>${googleMapsApiKey ? `<script async defer src="https://maps.googleapis.com/maps/api/js?key=${googleMapsApiKey}"></script>` : ''}</head>`
           )
         )
       )

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,13 +1,13 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core'
 import { provideServerRendering } from '@angular/platform-server'
 import { appConfig } from './app.config'
-import { API_BASE_URL, DEFAULT_API_BASE_URL } from './config/api.config'
+import { API_BASE_URL, DEFAULT_API_BASE_URL, RECAPTCHA_SITE_KEY, DEFAULT_RECAPTCHA_SITE_KEY } from './config/api.config'
 
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),
-    // On the server, the API host comes from the runtime environment.
-    { provide: API_BASE_URL, useFactory: () => process.env['API_URL'] ?? DEFAULT_API_BASE_URL }
+    { provide: API_BASE_URL, useFactory: () => process.env['API_URL'] ?? DEFAULT_API_BASE_URL },
+    { provide: RECAPTCHA_SITE_KEY, useFactory: () => process.env['RECAPTCHA_SITE_KEY'] ?? DEFAULT_RECAPTCHA_SITE_KEY }
   ]
 }
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -9,7 +9,7 @@ import { requestInterceptor } from './interceptors/request.interceptor'
 import { authInterceptor } from './interceptors/auth.interceptor'
 import { loaderInterceptor } from './interceptors/loader.interceptor'
 import { sesionInterceptor } from './interceptors/sesion.interceptor'
-import { API_BASE_URL, DEFAULT_API_BASE_URL } from './config/api.config'
+import { API_BASE_URL, DEFAULT_API_BASE_URL, RECAPTCHA_SITE_KEY, DEFAULT_RECAPTCHA_SITE_KEY } from './config/api.config'
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -19,8 +19,13 @@ export const appConfig: ApplicationConfig = {
     provideAnimationsAsync(),
     {
       provide: API_BASE_URL,
-      // Injected by the SSR server into the HTML at request time; falls back for `ng serve`.
       useFactory: () => (globalThis as unknown as { __API_URL__?: string }).__API_URL__ ?? DEFAULT_API_BASE_URL
+    },
+    {
+      provide: RECAPTCHA_SITE_KEY,
+      useFactory: () =>
+        (globalThis as unknown as { __RECAPTCHA_SITE_KEY__?: string }).__RECAPTCHA_SITE_KEY__ ??
+        DEFAULT_RECAPTCHA_SITE_KEY
     }
   ]
 }

--- a/src/app/config/api.config.ts
+++ b/src/app/config/api.config.ts
@@ -14,3 +14,8 @@ export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL')
 
 /** Fallback used for local dev when no runtime value is provided. */
 export const DEFAULT_API_BASE_URL = 'http://localhost:8080'
+
+export const RECAPTCHA_SITE_KEY = new InjectionToken<string>('RECAPTCHA_SITE_KEY')
+
+/** Google's public test key — only for local dev. Set RECAPTCHA_SITE_KEY in Railway for production. */
+export const DEFAULT_RECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'

--- a/src/app/pages/login-entidad/login-entidad.component.ts
+++ b/src/app/pages/login-entidad/login-entidad.component.ts
@@ -13,10 +13,11 @@ import { Login } from '../../services/interfaces/login'
 import { LocalAdheridoService } from '../../services/local-adherido/local-adherido.service'
 import { ResponsableService } from '../../services/responsable/responsable.service'
 import { CommonModule } from '@angular/common'
-import { Component, inject } from '@angular/core'
+import { Component, inject, Inject } from '@angular/core'
 import { EntidadService } from '../../services/entidad/entidad.service'
 import { SesionService } from '../../services/sesion/sesion.service'
 import { RecaptchaModule, RecaptchaFormsModule } from 'ng-recaptcha'
+import { RECAPTCHA_SITE_KEY } from '../../config/api.config'
 import { switchMap } from 'rxjs'
 
 @Component({
@@ -44,15 +45,17 @@ export class LoginEntidadComponent {
   router = inject(Router)
   hide = true
   recaptchaToken = ''
-  recaptchaSiteKey = '6Lfgqq8sAAAAALwsy8mZSWfWJeoIfoxHAwQ6Vbhy'
+  recaptchaSiteKey: string
 
   form: FormGroup
 
   constructor(
+    @Inject(RECAPTCHA_SITE_KEY) recaptchaSiteKey: string,
     private fb: FormBuilder,
     private entidadServ: EntidadService,
     private sesionService: SesionService
   ) {
+    this.recaptchaSiteKey = recaptchaSiteKey
     this.form = this.fb.group({
       username: ['', [Validators.required]],
       password: ['', [Validators.required]]

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,5 +1,5 @@
 import { StorageService } from '../../services/storage/storage.service'
-import { Component, inject } from '@angular/core'
+import { Component, inject, Inject } from '@angular/core'
 
 import { MatButtonModule } from '@angular/material/button'
 import { MatIconModule } from '@angular/material/icon'
@@ -17,6 +17,7 @@ import { ResponsableService } from '../../services/responsable/responsable.servi
 import { CommonModule } from '@angular/common'
 import { SesionService } from '../../services/sesion/sesion.service'
 import { RecaptchaModule, RecaptchaFormsModule } from 'ng-recaptcha'
+import { RECAPTCHA_SITE_KEY } from '../../config/api.config'
 import { catchError, map, of } from 'rxjs'
 
 type Role = 'neighbor' | 'reward-partner' | 'responsible'
@@ -54,17 +55,19 @@ export class LoginComponent {
   loginAs = 0
   userRole: string[] = ['Vecino', 'Local adherido', 'Responsable']
   recaptchaToken = ''
-  recaptchaSiteKey = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+  recaptchaSiteKey: string
 
   form: FormGroup
 
   constructor(
+    @Inject(RECAPTCHA_SITE_KEY) recaptchaSiteKey: string,
     private fb: FormBuilder,
     private neighborService: VecinoService,
     private businessService: LocalAdheridoService,
     private responsibleService: ResponsableService,
     private sesionService: SesionService
   ) {
+    this.recaptchaSiteKey = recaptchaSiteKey
     this.form = this.fb.group({
       username: ['', [Validators.required]],
       password: ['', [Validators.required]]

--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
   <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCaKbVhcX_22R_pRKDYuNA7vox-PtGaDkI"></script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
- recaptcha site key injected via SSR server (RECAPTCHA_SITE_KEY)
- google maps api key injected via SSR server (GOOGLE_MAPS_API_KEY)
- both exposed to browser via window globals, same pattern as API_BASE_URL