### PR TITLE
feat(registration): verify email via OTP before creating account

### DIFF
--- a/src/app/pages/registrar-local/registrar-local.component.ts
+++ b/src/app/pages/registrar-local/registrar-local.component.ts
@@ -107,37 +107,18 @@ export class RegistrarLocalComponent implements OnInit {
     })
 
     if (this.formGroup.valid) {
-      let localToSave = <LocalAdherido>this.formGroup.value
-      localToSave.coordinates = {
-        latitude: this.formGroup.get('latitude')?.value!,
-        longitude: this.formGroup.get('longitude')?.value!
-      }
-      localToSave.entityId = this.entitySelect
-      this.localService.create(localToSave).subscribe(
-        () => {
-          swalWithBootstrapButtons
-            .fire({
-              title: '¡Creado con éxito!',
-
-              icon: 'success'
-            })
-            .then(() => {
-              this.router.navigate([''])
-            })
+      const email = this.formGroup.get('email')?.value
+      // Paso 1: pedimos el código de verificación al mail antes de crear el local.
+      this.localService.requestRegisterOtp(email!).subscribe({
+        next: res => {
+          const registerToken = res.data?.registerToken
+          void this.verifyAndCreate(registerToken, swalWithBootstrapButtons)
         },
-        () => {
-          swalWithBootstrapButtons
-            .fire({
-              title: 'Ha ocurrido un error',
-              icon: 'error'
-            })
-            .then(result => {
-              if (result.isConfirmed) {
-                this.router.navigate(['/registrar-local'])
-              }
-            })
+        error: err => {
+          const title = err?.error?.message ?? 'No se pudo enviar el código de verificación'
+          swalWithBootstrapButtons.fire({ title, icon: 'error' })
         }
-      )
+      })
     } else {
       swalWithBootstrapButtons
         .fire({
@@ -150,6 +131,56 @@ export class RegistrarLocalComponent implements OnInit {
           }
         })
     }
+  }
+
+  private async verifyAndCreate(registerToken: string, swalWithBootstrapButtons: typeof Swal): Promise<void> {
+    // Paso 2: el usuario ingresa el OTP y RECIÉN ahí se crea el local.
+    const { value: otp } = await Swal.fire({
+      title: 'Verificá tu email',
+      text: 'Ingresá el código de 6 dígitos que enviamos a tu correo',
+      input: 'text',
+      inputAttributes: { maxlength: '6', inputmode: 'numeric', autocapitalize: 'off' },
+      showCancelButton: true,
+      confirmButtonText: 'Verificar',
+      cancelButtonText: 'Cancelar',
+      inputValidator: value => (!value || value.length !== 6 ? 'El código tiene 6 dígitos' : null)
+    })
+
+    if (!otp) return
+
+    let localToSave = <LocalAdherido>this.formGroup.value
+    localToSave.coordinates = {
+      latitude: this.formGroup.get('latitude')?.value!,
+      longitude: this.formGroup.get('longitude')?.value!
+    }
+    localToSave.entityId = this.entitySelect
+    ;(localToSave as any).registerToken = registerToken
+    ;(localToSave as any).otp = otp
+
+    this.localService.create(localToSave).subscribe(
+      () => {
+        swalWithBootstrapButtons
+          .fire({
+            title: '¡Creado con éxito!',
+            icon: 'success'
+          })
+          .then(() => {
+            this.router.navigate([''])
+          })
+      },
+      err => {
+        swalWithBootstrapButtons
+          .fire({
+            title: err?.error?.message ?? 'Ha ocurrido un error',
+            icon: 'error'
+          })
+          .then(result => {
+            if (result.isConfirmed) {
+              this.router.navigate(['/registrar-local'])
+            }
+          })
+      }
+    )
   }
 
   togglePasswordVisibility(): void {

--- a/src/app/pages/registrar-vecino/registrar-vecino.component.ts
+++ b/src/app/pages/registrar-vecino/registrar-vecino.component.ts
@@ -123,21 +123,51 @@ export class RegistrarVecinoComponent implements OnInit {
   onSubmit() {
     if (this.form.valid) {
       this.setDateFormat()
-      this.vecinoService.create(<Vecino>this.form.value).subscribe({
-        next: () => {
-          // El alta no inicia sesión: descartamos cualquier sesión previa viva
-          // en este dispositivo para no quedar navegando con otra identidad.
-          this.storage.clear()
-          Swal.fire({
-            icon: 'success',
-            title: 'Cuenta creada',
-            text: 'Ya podés iniciar sesión con tu nueva cuenta'
-          }).then(() => this.router.navigateByUrl('/login'))
+      const email = this.form.get('email')?.value
+      // Paso 1: pedimos el código de verificación al mail antes de crear la cuenta.
+      this.vecinoService.requestRegisterOtp(email).subscribe({
+        next: res => {
+          const registerToken = res.data?.registerToken
+          void this.verifyAndCreate(registerToken)
         },
-        error: () => {
-          Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo crear la cuenta' })
+        error: err => {
+          const text = err?.error?.message ?? 'No se pudo enviar el código de verificación'
+          Swal.fire({ icon: 'error', title: 'Error', text })
         }
       })
     }
+  }
+
+  private async verifyAndCreate(registerToken: string): Promise<void> {
+    // Paso 2: el usuario ingresa el OTP y RECIÉN ahí se crea la cuenta.
+    const { value: otp } = await Swal.fire({
+      title: 'Verificá tu email',
+      text: 'Ingresá el código de 6 dígitos que enviamos a tu correo',
+      input: 'text',
+      inputAttributes: { maxlength: '6', inputmode: 'numeric', autocapitalize: 'off' },
+      showCancelButton: true,
+      confirmButtonText: 'Verificar',
+      cancelButtonText: 'Cancelar',
+      inputValidator: value => (!value || value.length !== 6 ? 'El código tiene 6 dígitos' : null)
+    })
+
+    if (!otp) return
+
+    this.vecinoService.create(<Vecino>{ ...this.form.value, registerToken, otp }).subscribe({
+      next: () => {
+        // El alta no inicia sesión: descartamos cualquier sesión previa viva
+        // en este dispositivo para no quedar navegando con otra identidad.
+        this.storage.clear()
+        Swal.fire({
+          icon: 'success',
+          title: 'Cuenta creada',
+          text: 'Ya podés iniciar sesión con tu nueva cuenta'
+        }).then(() => this.router.navigateByUrl('/login'))
+      },
+      error: err => {
+        const text = err?.error?.message ?? 'No se pudo crear la cuenta'
+        Swal.fire({ icon: 'error', title: 'Error', text })
+      }
+    })
   }
 }

--- a/src/app/services/local-adherido/local-adherido.service.ts
+++ b/src/app/services/local-adherido/local-adherido.service.ts
@@ -25,6 +25,9 @@ export class LocalAdheridoService {
   create(object: LocalAdherido): Observable<LocalAdherido> {
     return this.http.post<LocalAdherido>(this.url, object)
   }
+  requestRegisterOtp(email: string): Observable<any> {
+    return this.http.post<any>(`${this.apiBase}/api/auth/register/request-otp`, { email, userType: 'reward-partner' })
+  }
 
   login(object: Login): Observable<any> {
     return this.http.post<LoginResponse>(this.url + '/auth/login', object)

--- a/src/app/services/vecino/vecino.service.ts
+++ b/src/app/services/vecino/vecino.service.ts
@@ -21,6 +21,9 @@ export class VecinoService {
   create(object: Vecino): Observable<Vecino> {
     return this.http.post<Vecino>(this.url, object)
   }
+  requestRegisterOtp(email: string): Observable<any> {
+    return this.http.post<any>(`${this.apiBase}/api/auth/register/request-otp`, { email, userType: 'neighbor' })
+  }
   update(object: VecinoUpdate, id: string): Observable<VecinoUpdate> {
     return this.http.put<VecinoUpdate>(this.url + '/' + id, object)
   }


### PR DESCRIPTION
Vecino and local registration now request a verification code before creating the account:

- requestRegisterOtp() in the vecino and local services hits /api/auth/register/request-otp
- registrar-vecino and registrar-local: on submit, request the OTP, prompt the 6-digit code via a SweetAlert2 modal, then create with { registerToken, otp }