### PR TITLE
feat(notification): agregar push notifications web y actualizaciones …

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,7 +38,8 @@
             "prerender": false,
             "ssr": {
               "entry": "server.ts"
-            }
+            },
+            "serviceWorker": "ngsw-config.json"
           },
           "configurations": {
             "production": {

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "app",
+      "installMode": "prefetch",
+      "resources": {
+        "files": [
+          "/favicon.ico",
+          "/index.html",
+          "/manifest.webmanifest",
+          "/*.css",
+          "/*.js"
+        ]
+      }
+    },
+    {
+      "name": "assets",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/**",
+          "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
+        ]
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@angular/platform-browser-dynamic": "17.3.12",
     "@angular/platform-server": "17.3.12",
     "@angular/router": "17.3.12",
+    "@angular/service-worker": "17.3.12",
     "@angular/ssr": "17.3.8",
     "@emailjs/browser": "4.4.1",
     "@fortawesome/angular-fontawesome": "0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@angular/router':
         specifier: 17.3.12
         version: 17.3.12(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(@angular/platform-browser@17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(rxjs@7.8.1)
+      '@angular/service-worker':
+        specifier: 17.3.12
+        version: 17.3.12(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))
       '@angular/ssr':
         specifier: 17.3.8
         version: 17.3.8(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))
@@ -125,7 +128,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 17.3.8
-        version: 17.3.8(4tsjofs5yogc7dh4odxe3d4u2y)
+        version: 17.3.8(6rcx26pdvs6k7ferlx6duxl46e)
       '@angular/cli':
         specifier: 17.3.8
         version: 17.3.8(chokidar@3.6.0)
@@ -401,6 +404,14 @@ packages:
       '@angular/core': 17.3.12
       '@angular/platform-browser': 17.3.12
       rxjs: ^6.5.3 || ^7.4.0
+
+  '@angular/service-worker@17.3.12':
+    resolution: {integrity: sha512-Y83+oTZ2XPO7P2Yok78JNlXDDXbP7Qr+HN6ifpPXWmUS4MwFEyXByCl3Hlz9VMxnrKvPYWvzHKWfT0S20XZsvA==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    hasBin: true
+    peerDependencies:
+      '@angular/common': 17.3.12
+      '@angular/core': 17.3.12
 
   '@angular/ssr@17.3.8':
     resolution: {integrity: sha512-qsCMMR7wEOlbPbqTOrcr/1hEoQjIQOGqq6stbK9J52IebTyzC+rZNzDjJcL9e39nSmvbIeCUaN1XquebQ12/pw==}
@@ -5441,11 +5452,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@17.3.8(4tsjofs5yogc7dh4odxe3d4u2y)':
+  '@angular-devkit/build-angular@17.3.8(6rcx26pdvs6k7ferlx6duxl46e)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1703.8(chokidar@3.6.0)
-      '@angular-devkit/build-webpack': 0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3))(webpack@5.90.3)
+      '@angular-devkit/build-webpack': 0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3))(webpack@5.90.3(esbuild@0.20.1))
       '@angular-devkit/core': 17.3.8(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5)
       '@babel/core': 7.24.0
@@ -5458,16 +5469,16 @@ snapshots:
       '@babel/preset-env': 7.24.0(@babel/core@7.24.0)
       '@babel/runtime': 7.24.0
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3)
+      '@ngtools/webpack': 17.3.8(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.1.7(@types/node@18.19.43)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.18(postcss@8.4.35)
-      babel-loader: 9.1.3(@babel/core@7.24.0)(webpack@5.90.3)
+      babel-loader: 9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.20.1))
       babel-plugin-istanbul: 6.1.1
       browserslist: 4.23.1
-      copy-webpack-plugin: 11.0.0(webpack@5.90.3)
+      copy-webpack-plugin: 11.0.0(webpack@5.90.3(esbuild@0.20.1))
       critters: 0.0.22
-      css-loader: 6.10.0(webpack@5.90.3)
+      css-loader: 6.10.0(webpack@5.90.3(esbuild@0.20.1))
       esbuild-wasm: 0.20.1
       fast-glob: 3.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
@@ -5476,11 +5487,11 @@ snapshots:
       jsonc-parser: 3.2.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 11.1.0(less@4.2.0)(webpack@5.90.3)
-      license-webpack-plugin: 4.0.2(webpack@5.90.3)
+      less-loader: 11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.20.1))
+      license-webpack-plugin: 4.0.2(webpack@5.90.3(esbuild@0.20.1))
       loader-utils: 3.2.1
       magic-string: 0.30.8
-      mini-css-extract-plugin: 2.8.1(webpack@5.90.3)
+      mini-css-extract-plugin: 2.8.1(webpack@5.90.3(esbuild@0.20.1))
       mrmime: 2.0.0
       open: 8.4.2
       ora: 5.4.1
@@ -5488,13 +5499,13 @@ snapshots:
       picomatch: 4.0.1
       piscina: 4.4.0
       postcss: 8.4.35
-      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3)
+      postcss-loader: 8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.71.1
-      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.90.3)
+      sass-loader: 14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.20.1))
       semver: 7.6.0
-      source-map-loader: 5.0.0(webpack@5.90.3)
+      source-map-loader: 5.0.0(webpack@5.90.3(esbuild@0.20.1))
       source-map-support: 0.5.21
       terser: 5.29.1
       tree-kill: 1.2.2
@@ -5504,13 +5515,14 @@ snapshots:
       vite: 5.1.7(@types/node@18.19.43)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
       watchpack: 2.4.0
       webpack: 5.90.3(esbuild@0.20.1)
-      webpack-dev-middleware: 6.1.2(webpack@5.90.3)
+      webpack-dev-middleware: 6.1.2(webpack@5.90.3(esbuild@0.20.1))
       webpack-dev-server: 4.15.1(webpack@5.90.3)
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.90.3)
+      webpack-subresource-integrity: 5.1.0(webpack@5.90.3(esbuild@0.20.1))
     optionalDependencies:
       '@angular/localize': 17.3.12(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5))(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))
       '@angular/platform-server': 17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(@angular/platform-browser@17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))
+      '@angular/service-worker': 17.3.12(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))
       esbuild: 0.20.1
       karma: 6.4.4
     transitivePeerDependencies:
@@ -5532,7 +5544,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3))(webpack@5.90.3)':
+  '@angular-devkit/build-webpack@0.1703.8(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3))(webpack@5.90.3(esbuild@0.20.1))':
     dependencies:
       '@angular-devkit/architect': 0.1703.8(chokidar@3.6.0)
       rxjs: 7.8.1
@@ -5752,6 +5764,12 @@ snapshots:
       '@angular/platform-browser': 17.3.12(@angular/animations@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))
       rxjs: 7.8.1
       tslib: 2.6.3
+
+  '@angular/service-worker@17.3.12(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))':
+    dependencies:
+      '@angular/common': 17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1)
+      '@angular/core': 17.3.12(rxjs@7.8.1)(zone.js@0.14.10)
+      tslib: 2.8.1
 
   '@angular/ssr@17.3.8(@angular/common@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))(rxjs@7.8.1))(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10))':
     dependencies:
@@ -7539,7 +7557,7 @@ snapshots:
       rxjs: 7.8.1
       tslib: 2.6.3
 
-  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3)':
+  '@ngtools/webpack@17.3.8(@angular/compiler-cli@17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5))(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1))':
     dependencies:
       '@angular/compiler-cli': 17.3.12(@angular/compiler@17.3.12(@angular/core@17.3.12(rxjs@7.8.1)(zone.js@0.14.10)))(typescript@5.4.5)
       typescript: 5.4.5
@@ -8212,7 +8230,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  babel-loader@9.1.3(@babel/core@7.24.0)(webpack@5.90.3):
+  babel-loader@9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       '@babel/core': 7.24.0
       find-cache-dir: 4.0.0
@@ -8549,7 +8567,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@11.0.0(webpack@5.90.3):
+  copy-webpack-plugin@11.0.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -8602,7 +8620,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@6.10.0(webpack@5.90.3):
+  css-loader@6.10.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.35)
       postcss: 8.4.35
@@ -10057,7 +10075,7 @@ snapshots:
       picocolors: 1.0.1
       shell-quote: 1.8.1
 
-  less-loader@11.1.0(less@4.2.0)(webpack@5.90.3):
+  less-loader@11.1.0(less@4.2.0)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       klona: 2.0.6
       less: 4.2.0
@@ -10082,7 +10100,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.90.3):
+  license-webpack-plugin@4.0.2(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -10275,7 +10293,7 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mini-css-extract-plugin@2.8.1(webpack@5.90.3):
+  mini-css-extract-plugin@2.8.1(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -10718,7 +10736,7 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3):
+  postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.4.5)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.6
@@ -10992,7 +11010,7 @@ snapshots:
 
   safevalues@0.3.4: {}
 
-  sass-loader@14.1.1(sass@1.71.1)(webpack@5.90.3):
+  sass-loader@14.1.1(sass@1.71.1)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -11230,7 +11248,7 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-loader@5.0.0(webpack@5.90.3):
+  source-map-loader@5.0.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
@@ -11386,7 +11404,7 @@ snapshots:
   synckit@0.8.8:
     dependencies:
       '@pkgr/core': 0.1.1
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   tapable@2.2.1: {}
 
@@ -11629,7 +11647,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.90.3(esbuild@0.20.1)
 
-  webpack-dev-middleware@6.1.2(webpack@5.90.3):
+  webpack-dev-middleware@6.1.2(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -11687,7 +11705,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.90.3):
+  webpack-subresource-integrity@5.1.0(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.90.3(esbuild@0.20.1)

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,11 @@
-import { ApplicationConfig } from '@angular/core'
+import { ApplicationConfig, isDevMode } from '@angular/core'
 import { provideRouter, withViewTransitions } from '@angular/router'
 
 import { routes } from './app.routes'
 import { provideClientHydration, withNoHttpTransferCache } from '@angular/platform-browser'
 import { provideHttpClient, withInterceptors } from '@angular/common/http'
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'
+import { provideServiceWorker } from '@angular/service-worker'
 import { requestInterceptor } from './interceptors/request.interceptor'
 import { authInterceptor } from './interceptors/auth.interceptor'
 import { loaderInterceptor } from './interceptors/loader.interceptor'
@@ -22,6 +23,13 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(withNoHttpTransferCache()),
     provideHttpClient(withInterceptors([requestInterceptor, loaderInterceptor, authInterceptor, sesionInterceptor])),
     provideAnimationsAsync(),
+    // El service worker de Angular es lo que permite recibir push con la app cerrada
+    // (SwPush escucha el evento 'push' y muestra la notificación del sistema).
+    // Deshabilitado en dev porque interfiere con el hot-reload.
+    provideServiceWorker('ngsw-worker.js', {
+      enabled: !isDevMode(),
+      registrationStrategy: 'registerWhenStable:30000'
+    }),
     {
       provide: API_BASE_URL,
       useFactory: () => (globalThis as unknown as { __API_URL__?: string }).__API_URL__ ?? DEFAULT_API_BASE_URL

--- a/src/app/components/animated-number/animated-number.component.ts
+++ b/src/app/components/animated-number/animated-number.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input, OnChanges, OnDestroy, PLATFORM_ID, SimpleChanges, inject, signal } from '@angular/core'
+import { isPlatformBrowser } from '@angular/common'
+
+@Component({
+  selector: 'app-animated-number',
+  standalone: true,
+  template: '{{ displayValue() }}'
+})
+export class AnimatedNumberComponent implements OnChanges, OnDestroy {
+  @Input({ required: true }) value = 0
+  @Input() durationMs = 700
+
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID))
+  private frameId: number | null = null
+  private initialized = false
+
+  readonly displayValue = signal(0)
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const change = changes['value']
+    if (change == null) return
+
+    // Primera carga (llega el valor inicial de la página): se muestra directo,
+    // sin animar desde 0 -- la animación es para cambios EN VIVO, no para el load.
+    if (!this.initialized) {
+      this.initialized = true
+      this.displayValue.set(this.value)
+      return
+    }
+
+    const from = (change.previousValue as number) ?? this.value
+    const to = change.currentValue as number
+    if (from === to) return
+
+    this.animate(from, to)
+  }
+
+  ngOnDestroy(): void {
+    if (this.frameId != null && this.isBrowser) cancelAnimationFrame(this.frameId)
+  }
+
+  private animate(from: number, to: number): void {
+    if (!this.isBrowser) {
+      this.displayValue.set(to)
+      return
+    }
+    if (this.frameId != null) cancelAnimationFrame(this.frameId)
+
+    const start = performance.now()
+    const step = (now: number): void => {
+      const progress = Math.min((now - start) / this.durationMs, 1)
+      const eased = 1 - Math.pow(1 - progress, 3)
+      this.displayValue.set(Math.round(from + (to - from) * eased))
+
+      this.frameId = progress < 1 ? requestAnimationFrame(step) : null
+    }
+    this.frameId = requestAnimationFrame(step)
+  }
+}

--- a/src/app/components/notification-panel/notification-panel.component.html
+++ b/src/app/components/notification-panel/notification-panel.component.html
@@ -1,5 +1,10 @@
 <app-bottom-sheet [handle]="false" (closed)="onSheetClosed()">
   <div class="panel-header">
+    @if (pushSupported()) {
+      <button type="button" class="icon-btn" (click)="togglePush()" [attr.aria-label]="pushSubscribed() ? 'Desactivar notificaciones push' : 'Activar notificaciones push'">
+        <mat-icon>{{ pushSubscribed() ? 'notifications_active' : 'notifications_off' }}</mat-icon>
+      </button>
+    }
     <span class="panel-title">Notificaciones</span>
     @if (hasUnread()) {
       <button type="button" class="mark-all-btn" (click)="markAllAsRead()">Marcar todas como leídas</button>

--- a/src/app/components/notification-panel/notification-panel.component.scss
+++ b/src/app/components/notification-panel/notification-panel.component.scss
@@ -1,20 +1,40 @@
 .panel-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
-  padding: 4px 4px 14px;
+  padding: 20px 24px 18px;
   border-bottom: 1px solid var(--line);
 }
 
 .panel-title {
+  grid-column: 2;
+  justify-self: center;
   font-family: 'Sora', sans-serif;
   font-weight: 700;
   font-size: 18px;
   color: var(--ink);
 }
 
+.icon-btn {
+  grid-column: 1;
+  justify-self: start;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
 .mark-all-btn {
+  grid-column: 3;
+  justify-self: end;
   border: none;
   background: none;
   color: var(--accent);

--- a/src/app/components/notification-panel/notification-panel.component.ts
+++ b/src/app/components/notification-panel/notification-panel.component.ts
@@ -4,6 +4,7 @@ import { MatIconModule } from '@angular/material/icon'
 import { BottomSheetComponent } from '../bottom-sheet/bottom-sheet.component'
 import { SkeletonComponent } from '../skeleton/skeleton.component'
 import { NotificationService } from '../../services/notification/notification.service'
+import { PushNotificationService } from '../../services/notification/push-notification.service'
 import { Notification, NotificationCategory } from '../../services/interfaces/notification'
 
 const CATEGORY_ICONS: Record<NotificationCategory, string> = {
@@ -24,14 +25,18 @@ export class NotificationPanelComponent {
   @Output() closed = new EventEmitter<void>()
 
   private readonly notificationService = inject(NotificationService)
+  private readonly pushNotificationService = inject(PushNotificationService)
   private readonly sheet = viewChild.required(BottomSheetComponent)
 
   readonly loading = signal(true)
   readonly notifications = signal<Notification[]>([])
+  readonly pushSupported = signal(false)
+  readonly pushSubscribed = signal(false)
 
   open(): void {
     this.sheet().open()
     this.fetch()
+    this.refreshPushState()
   }
 
   closeSheet(): void {
@@ -63,6 +68,25 @@ export class NotificationPanelComponent {
     const now = new Date().toISOString()
     this.notifications.update(list => list.map(n => ({ ...n, readAt: n.readAt ?? now })))
     this.notificationService.markAllAsRead().subscribe({ error: () => {} })
+  }
+
+  async togglePush(): Promise<void> {
+    try {
+      if (this.pushSubscribed()) {
+        await this.pushNotificationService.unsubscribe()
+      } else {
+        await this.pushNotificationService.subscribe()
+      }
+    } catch (error) {
+      console.error('No se pudo actualizar la suscripción a notificaciones push', error)
+    }
+    await this.refreshPushState()
+  }
+
+  private async refreshPushState(): Promise<void> {
+    this.pushSupported.set(this.pushNotificationService.isSupported)
+    if (!this.pushSupported()) return
+    this.pushSubscribed.set(await this.pushNotificationService.isSubscribed())
   }
 
   private fetch(): void {

--- a/src/app/layouts/role-layout/role-layout.component.ts
+++ b/src/app/layouts/role-layout/role-layout.component.ts
@@ -1,15 +1,16 @@
 import { StorageService } from '../../services/storage/storage.service'
-import { Component, DestroyRef, OnInit, inject, viewChild } from '@angular/core'
+import { Component, DestroyRef, OnDestroy, OnInit, PLATFORM_ID, inject, viewChild } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, NavigationStart, Router, RouterModule, RouterOutlet } from '@angular/router'
 import { BreakpointObserver } from '@angular/cdk/layout'
 import { filter } from 'rxjs'
+import { isPlatformBrowser, CommonModule } from '@angular/common'
 import { SidenavComponent } from '../../components/sidenav/sidenav.component'
 import { MobileTabbarComponent, TabExtraItem } from '../../components/mobile-tabbar/mobile-tabbar.component'
 import { MobileMenuComponent, MobileMenuItem } from '../../components/mobile-menu/mobile-menu.component'
 import { MobileOptionsSheetComponent } from '../../components/mobile-options-sheet/mobile-options-sheet.component'
 import { SesionService } from '../../services/sesion/sesion.service'
-import { CommonModule } from '@angular/common'
+import { RealtimeService } from '../../services/notification/realtime.service'
 
 @Component({
   selector: 'app-role-layout',
@@ -26,12 +27,14 @@ import { CommonModule } from '@angular/common'
   templateUrl: './role-layout.component.html',
   styleUrl: './role-layout.component.scss'
 })
-export class RoleLayoutComponent implements OnInit {
+export class RoleLayoutComponent implements OnInit, OnDestroy {
   private storage = inject(StorageService)
   private route = inject(ActivatedRoute)
   private router = inject(Router)
   private breakpointObserver = inject(BreakpointObserver)
   private sesionService = inject(SesionService)
+  private realtimeService = inject(RealtimeService)
+  private platformId = inject(PLATFORM_ID)
   private destroyRef = inject(DestroyRef)
 
   role = 'vecino'
@@ -56,6 +59,12 @@ export class RoleLayoutComponent implements OnInit {
   userDetail = ''
 
   ngOnInit(): void {
+    // El stream SSE solo tiene sentido en el navegador (SSR no mantiene
+    // conexiones abiertas) y una vez que hay sesión.
+    if (isPlatformBrowser(this.platformId)) {
+      this.realtimeService.start()
+    }
+
     this.role = this.route.snapshot.data['role'] || 'vecino'
     this.userId = this.sesionService.getUserId()
 
@@ -145,6 +154,10 @@ export class RoleLayoutComponent implements OnInit {
         this.menu()?.closeSheet()
         this.optionsSheet()?.closeSheet()
       })
+  }
+
+  ngOnDestroy(): void {
+    this.realtimeService.stop()
   }
 
   onHamburgerClick(): void {

--- a/src/app/pages/catalogo-cupones/catalogo-cupones.component.ts
+++ b/src/app/pages/catalogo-cupones/catalogo-cupones.component.ts
@@ -1,5 +1,6 @@
 import { StorageService } from '../../services/storage/storage.service'
-import { inject, Component, ViewChild, PLATFORM_ID } from '@angular/core'
+import { inject, Component, DestroyRef, ViewChild, PLATFORM_ID } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { MatTableDataSource } from '@angular/material/table'
 import { MatIconModule } from '@angular/material/icon'
 import { CuponSheetComponent } from '../../components/cupon-sheet/cupon-sheet.component'
@@ -7,8 +8,9 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
 import { LocalAdheridoService } from '../../services/local-adherido/local-adherido.service'
 import { SesionService } from '../../services/sesion/sesion.service'
 import { VecinoService } from '../../services/vecino/vecino.service'
+import { RealtimeService } from '../../services/notification/realtime.service'
 import { Coupon } from '../../services/interfaces/coupon'
-import { forkJoin } from 'rxjs'
+import { forkJoin, filter } from 'rxjs'
 import { isPlatformBrowser } from '@angular/common'
 import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
 
@@ -24,6 +26,8 @@ export type CampoOrdenCupon = 'discount' | 'costInPoints' | 'validDays'
 export class CatalogoCuponesComponent {
   private storage = inject(StorageService)
   private platformId = inject(PLATFORM_ID)
+  private realtimeService = inject(RealtimeService)
+  private destroyRef = inject(DestroyRef)
   @ViewChild(CuponSheetComponent) sheet?: CuponSheetComponent
   loading = true
   dataSource: MatTableDataSource<any> = new MatTableDataSource()
@@ -68,6 +72,15 @@ export class CatalogoCuponesComponent {
     // servidor renderiza el skeleton en la pantalla correcta.
     if (isPlatformBrowser(this.platformId)) {
       this.getItems()
+
+      // Cuando un local crea un cupón nuevo para esta entidad, refrescamos el
+      // catálogo en vivo (sin que el vecino tenga que recargar la página).
+      this.realtimeService.events$
+        .pipe(
+          filter(event => event.category === 'COUPON_CREATED'),
+          takeUntilDestroyed(this.destroyRef)
+        )
+        .subscribe(() => this.getItems())
     }
   }
 

--- a/src/app/pages/landing-vecino/landing-vecino.component.html
+++ b/src/app/pages/landing-vecino/landing-vecino.component.html
@@ -2,7 +2,7 @@
   <app-page-header [title]="'¡Hola, ' + name + '! 🎉'">
     <div class="hdr-chip">
       <mat-icon>stars</mat-icon>
-      {{ puntos }} pts acumulados
+      <app-animated-number [value]="puntos()" /> pts acumulados
     </div>
     <app-notification-bell #bell (opened)="panel.open()" />
   </app-page-header>

--- a/src/app/pages/landing-vecino/landing-vecino.component.ts
+++ b/src/app/pages/landing-vecino/landing-vecino.component.ts
@@ -1,5 +1,6 @@
 import { StorageService } from '../../services/storage/storage.service'
-import { inject, Component, OnInit, PLATFORM_ID } from '@angular/core'
+import { inject, Component, DestroyRef, OnInit, PLATFORM_ID } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { MatButtonModule } from '@angular/material/button'
 import { MatIconModule } from '@angular/material/icon'
 import { MatListModule } from '@angular/material/list'
@@ -7,11 +8,15 @@ import { MatDividerModule } from '@angular/material/divider'
 import { MatToolbarModule } from '@angular/material/toolbar'
 import { RouterModule } from '@angular/router'
 import { BreakpointObserver } from '@angular/cdk/layout'
+import { filter } from 'rxjs'
 import { SidenavComponent } from '../../components/sidenav/sidenav.component'
 import { PageHeaderComponent } from '../../components/page-header/page-header.component'
 import { NotificationBellComponent } from '../../components/notification-bell/notification-bell.component'
 import { NotificationPanelComponent } from '../../components/notification-panel/notification-panel.component'
+import { AnimatedNumberComponent } from '../../components/animated-number/animated-number.component'
 import { VecinoService } from '../../services/vecino/vecino.service'
+import { SesionService } from '../../services/sesion/sesion.service'
+import { RealtimeService } from '../../services/notification/realtime.service'
 import { CommonModule, DatePipe, isPlatformBrowser } from '@angular/common'
 import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
 
@@ -28,6 +33,7 @@ import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
     PageHeaderComponent,
     NotificationBellComponent,
     NotificationPanelComponent,
+    AnimatedNumberComponent,
     RouterModule,
     CommonModule,
     DatePipe,
@@ -39,10 +45,13 @@ import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
 export class LandingVecinoComponent implements OnInit {
   private storage = inject(StorageService)
   private platformId = inject(PLATFORM_ID)
+  private sesionService = inject(SesionService)
+  private realtimeService = inject(RealtimeService)
+  private destroyRef = inject(DestroyRef)
   loading = true
   title = 'GreenBin'
   id = ''
-  puntos: string = ''
+  readonly puntos = this.sesionService.points
   name = ''
   historial: any[] = []
   historialVisible: any[] = []
@@ -71,9 +80,22 @@ export class LandingVecinoComponent implements OnInit {
     if (!isPlatformBrowser(this.platformId)) return
 
     this.vecinoServ.get(this.id).subscribe((resp: any) => {
-      this.puntos = resp.data.points
-      this.storage.setItem('points', this.puntos)
+      this.sesionService.setPoints(String(resp.data.points))
     })
+
+    // Cuando el responsable registra una entrega, el saldo sube en vivo (con
+    // animación) sin que el vecino tenga que recargar la página.
+    this.realtimeService.events$
+      .pipe(
+        filter(event => event.category === 'POINTS_DELIVERED'),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(event => {
+        const totalPoints = event.data?.['totalPoints']
+        if (typeof totalPoints === 'number') {
+          this.sesionService.setPoints(String(totalPoints))
+        }
+      })
 
     this.vecinoServ.getMyTransactions(this.id).subscribe({
       next: (resp: any) => {

--- a/src/app/services/notification/push-notification.service.ts
+++ b/src/app/services/notification/push-notification.service.ts
@@ -1,0 +1,48 @@
+import { inject, Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { SwPush } from '@angular/service-worker'
+import { firstValueFrom } from 'rxjs'
+import { filter, take } from 'rxjs/operators'
+import { API_BASE_URL } from '../../config/api.config'
+
+@Injectable({ providedIn: 'root' })
+export class PushNotificationService {
+  private readonly swPush = inject(SwPush)
+  private readonly http = inject(HttpClient)
+  private readonly apiBase = inject(API_BASE_URL)
+  private readonly url = `${this.apiBase}/api/notifications/push`
+
+  get isSupported(): boolean {
+    return this.swPush.isEnabled
+  }
+
+  async isSubscribed(): Promise<boolean> {
+    if (!this.isSupported) return false
+    const subscription = await firstValueFrom(this.swPush.subscription.pipe(take(1)))
+    return subscription != null
+  }
+
+  async subscribe(): Promise<void> {
+    if (!this.isSupported) return
+
+    const { data } = await firstValueFrom(this.http.get<{ data: { publicKey: string } }>(`${this.url}/public-key`))
+    const subscription = await this.swPush.requestSubscription({ serverPublicKey: data.publicKey })
+
+    await firstValueFrom(this.http.post(`${this.url}/subscribe`, subscription.toJSON()))
+  }
+
+  async unsubscribe(): Promise<void> {
+    if (!this.isSupported) return
+
+    const subscription = await firstValueFrom(
+      this.swPush.subscription.pipe(
+        filter((s): s is PushSubscription => s != null),
+        take(1)
+      )
+    )
+    if (subscription == null) return
+
+    await firstValueFrom(this.http.delete(`${this.url}/subscribe`, { body: { endpoint: subscription.endpoint } }))
+    await subscription.unsubscribe()
+  }
+}

--- a/src/app/services/notification/realtime.service.ts
+++ b/src/app/services/notification/realtime.service.ts
@@ -1,0 +1,106 @@
+import { inject, Injectable } from '@angular/core'
+import { Subject } from 'rxjs'
+import { API_BASE_URL } from '../../config/api.config'
+import { SesionService } from '../sesion/sesion.service'
+import { NotificationCategory } from '../interfaces/notification'
+
+export interface RealtimeEvent {
+  category: NotificationCategory
+  title: string
+  body: string
+  data?: Record<string, unknown>
+}
+
+const RECONNECT_DELAY_MS = 5000
+
+@Injectable({ providedIn: 'root' })
+export class RealtimeService {
+  private readonly apiBase = inject(API_BASE_URL)
+  private readonly sesionService = inject(SesionService)
+
+  private readonly eventsSubject = new Subject<RealtimeEvent>()
+  readonly events$ = this.eventsSubject.asObservable()
+
+  private abortController: AbortController | null = null
+  private stopped = false
+  private reconnectHandle: ReturnType<typeof setTimeout> | null = null
+
+  start(): void {
+    // requestSubscription ya en curso o pedido explícitamente detenido: no
+    // abrir una segunda conexión en paralelo.
+    if (this.abortController != null) return
+    this.stopped = false
+    void this.connect()
+  }
+
+  stop(): void {
+    this.stopped = true
+    if (this.reconnectHandle != null) {
+      clearTimeout(this.reconnectHandle)
+      this.reconnectHandle = null
+    }
+    this.abortController?.abort()
+    this.abortController = null
+  }
+
+  // fetch + ReadableStream en vez de EventSource nativo: EventSource no
+  // permite mandar el header Authorization, y poner el JWT como query param
+  // lo expone en logs del server/history del navegador. Con fetch podemos
+  // mandar el mismo Bearer token que ya usa el interceptor HTTP normal.
+  private async connect(): Promise<void> {
+    this.abortController = new AbortController()
+
+    try {
+      const response = await fetch(`${this.apiBase}/api/notifications/stream`, {
+        headers: {
+          Authorization: `Bearer ${this.sesionService.getAccessToken()}`,
+          Accept: 'text/event-stream'
+        },
+        signal: this.abortController.signal
+      })
+
+      if (response.body == null) {
+        this.scheduleReconnect()
+        return
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      for (;;) {
+        const { value, done } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const chunks = buffer.split('\n\n')
+        buffer = chunks.pop() ?? ''
+
+        for (const chunk of chunks) {
+          const dataLine = chunk.split('\n').find(line => line.startsWith('data:'))
+          if (dataLine == null) continue
+
+          try {
+            this.eventsSubject.next(JSON.parse(dataLine.slice('data:'.length).trim()) as RealtimeEvent)
+          } catch {
+            // Chunk corrupto/parcial: se ignora, no vale la pena tirar abajo la conexión por uno.
+          }
+        }
+      }
+    } catch {
+      // Abort intencional (stop()) o corte de red: en ambos casos cae acá,
+      // se distingue con `this.stopped` antes de reintentar.
+    }
+
+    this.abortController = null
+    this.scheduleReconnect()
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return
+    this.reconnectHandle = setTimeout(() => {
+      this.reconnectHandle = null
+      void this.connect()
+    }, RECONNECT_DELAY_MS)
+  }
+}

--- a/src/app/services/sesion/sesion.service.ts
+++ b/src/app/services/sesion/sesion.service.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from '../../config/api.config'
-import { inject, Injectable } from '@angular/core'
+import { inject, Injectable, signal } from '@angular/core'
 import { LoginResponse } from '../interfaces/login-response'
 import { BehaviorSubject, Observable, tap } from 'rxjs'
 import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http'
@@ -46,11 +46,21 @@ export class SesionService {
     this.router.navigateByUrl('/login')
   }
 
+  // Signal reactivo para UI que necesita enterarse de cambios de puntos en
+  // vivo (ej. contador animado). getPoints()/setPoints() siguen devolviendo
+  // el string crudo de siempre para no romper a nadie que ya los use.
+  readonly points = signal<number>(this.parsePoints(this.storage.getItem('points')))
+
   setPoints(data: string) {
     this.storage.setItem('points', data)
+    this.points.set(this.parsePoints(data))
   }
   getPoints() {
     return this.storage.getItem('points')!
+  }
+  private parsePoints(raw: string | null): number {
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) ? parsed : 0
   }
   setFirstname(data: string) {
     this.storage.setItem('firstname', data)


### PR DESCRIPTION
…en tiempo real

Consume desde el front los dos canales nuevos del backend: push del navegador (service worker) y SSE para estado en vivo.

- Service worker (@angular/service-worker) + PushNotificationService para suscribir/desuscribir push desde el panel de notificaciones
- RealtimeService conecta via fetch+ReadableStream (no EventSource, para poder mandar el Authorization header sin exponer el JWT en la URL)
- catalogo-cupones se refresca solo cuando aparece un cupon nuevo
- Signal de puntos reactivo en SesionService + AnimatedNumberComponent para animar el contador de puntos cuando llega una entrega en vivo
- Titulo del panel de notificaciones centrado y con mas margen