### PR TITLE
fix(sw): dejar de precachear index.html y forzar red fresca en navega…

### DIFF
--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/@angular/service-worker/config/schema.json",
   "index": "/index.html",
+  "navigationRequestStrategy": "freshness",
   "assetGroups": [
     {
       "name": "app",
@@ -8,7 +9,6 @@
       "resources": {
         "files": [
           "/favicon.ico",
-          "/index.html",
           "/manifest.webmanifest",
           "/*.css",
           "/*.js"


### PR DESCRIPTION
…ciones

El fix anterior (b039cf7) evitó que Express sirviera el index.html estático, pero el Service Worker de Angular seguía cacheando /index.html como asset con hash fijo e interceptando toda navegación con ese shell cacheado. Al ser SSR con env vars inyectadas por request, cualquier shell cacheado sin window.__API_URL__ quedaba serviendo localhost:8080 para siempre, causando el CORS/stream de notificaciones roto y la pantalla de carga infinita en puntos-verdes.

navigationRequestStrategy: freshness hace que las navegaciones vayan primero a la red (SSR real) y solo caigan a cache si falla la conexión.