### PR TITLE
fix(services): desenvolver y resguardar arrays en respuestas de list()

### DIFF
--- a/src/app/pages/entrega-residuos/entrega-residuos.component.ts
+++ b/src/app/pages/entrega-residuos/entrega-residuos.component.ts
@@ -65,7 +65,7 @@ export class EntregaResiduosComponent {
     private pvService: PuntoVerdeService
   ) {
     this.wasteCatServ.list(0, 100).subscribe(resp => {
-      this.categories = resp.map((category: any) => ({
+      this.categories = (resp ?? []).map((category: any) => ({
         ...category,
         disabled: false
       }))
@@ -88,7 +88,7 @@ export class EntregaResiduosComponent {
 
     const entidadInfo = JSON.parse(this.storage.getItem('entidadInfo') || '{}')
     this.pvService.list(entidadInfo.id).subscribe((res: any) => {
-      this.puntosVerdes = res
+      this.puntosVerdes = res ?? []
       const actual = this.puntosVerdes.find(p => p.id === pvGuardado)
       this.currentPvName = actual?.name ?? ''
     })

--- a/src/app/pages/landing-responsable/landing-responsable.component.ts
+++ b/src/app/pages/landing-responsable/landing-responsable.component.ts
@@ -66,7 +66,7 @@ export class LandingResponsableComponent implements OnInit {
     const entidadInfo = JSON.parse(this.storage.getItem('entidadInfo') || '{}')
     if (isPlatformBrowser(this.platformId)) {
       this.pvService.list(entidadInfo.id).subscribe((res: any) => {
-        this.listPtoVerde = res
+        this.listPtoVerde = res ?? []
       })
     }
     const ptoVerdeSeleccionado = this.storage.getItem('puntoVerde') || ''

--- a/src/app/services/local-adherido/local-adherido.service.ts
+++ b/src/app/services/local-adherido/local-adherido.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { inject, Injectable } from '@angular/core'
 import { StorageService } from '../storage/storage.service'
 import { LocalAdherido } from '../interfaces/local-adherido'
-import { Observable } from 'rxjs'
+import { Observable, map } from 'rxjs'
 import { Login } from '../interfaces/login'
 import { LoginResponse } from '../interfaces/login-response'
 
@@ -120,11 +120,11 @@ export class LocalAdheridoService {
     return this.http.put<any>(this.urlCoupon + '/' + id, { isAvailable: false, state: 'DISABLED' })
   }
 
-  list(entityId?: string, includeInactive = false): Observable<any> {
+  list(entityId?: string, includeInactive = false): Observable<LocalAdherido[]> {
     const query = new URLSearchParams()
     if (entityId) query.set('entityId', entityId)
     if (includeInactive) query.set('includeInactive', 'true')
     const params = query.toString() ? `?${query.toString()}` : ''
-    return this.http.get<any>(`${this.url}${params}`)
+    return this.http.get<any>(`${this.url}${params}`).pipe(map((resp: any) => resp.data ?? []))
   }
 }

--- a/src/app/services/punto-verde/punto-verde.service.ts
+++ b/src/app/services/punto-verde/punto-verde.service.ts
@@ -23,7 +23,7 @@ export class PuntoVerdeService {
     if (entityId) params += `&entityId=${entityId}`
     return this.http.get<PuntoVerde[]>(`${this.url}${params}`).pipe(
       map((resp: any) => {
-        return resp.data
+        return resp.data ?? []
       })
     )
   }

--- a/src/app/services/responsables/responsables.service.ts
+++ b/src/app/services/responsables/responsables.service.ts
@@ -20,7 +20,7 @@ export class ResponsablesService {
   list(offset: number, limit: number, entityId?: string): Observable<Responsable[]> {
     let params = `?offset=${offset}&limit=${limit}`
     if (entityId) params += `&entityId=${entityId}`
-    return this.http.get<Responsable[]>(`${this.url}${params}`).pipe(map((resp: any) => resp.data))
+    return this.http.get<Responsable[]>(`${this.url}${params}`).pipe(map((resp: any) => resp.data ?? []))
   }
   delete(id: string) {
     return this.http.delete(`${this.url}/${id}`)

--- a/src/app/services/wasteCategory/waste-category.service.ts
+++ b/src/app/services/wasteCategory/waste-category.service.ts
@@ -20,7 +20,7 @@ export class WasteCategoryService {
     if (includeInactive) params += `&includeInactive=true`
     return this.http.get<WasteCategory[]>(`${this.url}${params}`).pipe(
       map((resp: any) => {
-        return resp.data
+        return resp.data ?? []
       })
     )
   }


### PR DESCRIPTION
LocalAdheridoService.list() nunca desenvolvia resp.data: devolvia el objeto {status, message, data} completo, no un array. En visualizar-pv.component.ts eso se asigna directo a localesAdheridos, y el @for de map-view.component.html lo itera -> "t[Symbol.iterator] is not a function" al entrar al mapa.

De paso se resguardan con ?? [] los otros list() (punto-verde, responsables, wasteCategory) y sus callers, para que un data ausente o null no rompa el mismo tipo de iteracion.