### PR TITLE
fix(auth): reemplazar bottom-sheet de registro por pantalla completa

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -48,6 +48,13 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/login/login.component').then(m => m.LoginComponent)
   },
   {
+    path: 'registrarme',
+    loadComponent: () =>
+      import('./components/register-role-selector/register-role-selector.component').then(
+        m => m.RegisterRoleSelectorComponent
+      )
+  },
+  {
     path: 'login-admin',
     redirectTo: 'login',
     pathMatch: 'full'

--- a/src/app/components/mobile-options-sheet/mobile-options-sheet.component.ts
+++ b/src/app/components/mobile-options-sheet/mobile-options-sheet.component.ts
@@ -67,6 +67,7 @@ export class MobileOptionsSheetComponent implements OnInit, OnDestroy {
 
   @Output() close = new EventEmitter<void>()
   @Output() navigateFullPage = new EventEmitter<string>()
+  @Output() photoChanged = new EventEmitter<string>()
 
   private readonly sheet = viewChild.required(BottomSheetComponent)
   private readonly platformId = inject(PLATFORM_ID)
@@ -105,6 +106,7 @@ export class MobileOptionsSheetComponent implements OnInit, OnDestroy {
     if (!file) return
     this.revokePreview()
     this.previewPhoto = URL.createObjectURL(file)
+    this.photoChanged.emit(this.previewPhoto)
   }
 
   private revokePreview(): void {

--- a/src/app/components/register-role-selector/register-role-selector.component.html
+++ b/src/app/components/register-role-selector/register-role-selector.component.html
@@ -1,23 +1,38 @@
-<app-bottom-sheet>
+<div class="login-page has-form" data-role="vecino">
+  <div class="login-bg"></div>
+  <div class="login-card">
+    <div class="login-hero">
+      <div class="hero-icon"><mat-icon>recycling</mat-icon></div>
+      <h2>Bienvenido a GreenBin</h2>
+      <p>¿Cómo querés ingresar?</p>
+    </div>
 
-  <div class="role-hint">Elegí tu perfil para continuar</div>
-  <div class="roles">
-    <a class="role r-vec" routerLink="/registrar-vecino">
-      <span class="ri"><mat-icon>account_circle</mat-icon></span>
-      <div class="role-text">
-        <b>Vecino</b>
-        <span>Reciclá y ganá puntos</span>
+    <div class="login-body">
+      <div class="role-hint">Elegí tu perfil para continuar</div>
+      <div class="roles">
+        <a class="role r-vec" routerLink="/registrar-vecino">
+          <span class="ri"><mat-icon>account_circle</mat-icon></span>
+          <div class="role-text">
+            <b>Vecino</b>
+            <span>Reciclá y ganá puntos</span>
+          </div>
+          <mat-icon class="arr">chevron_right</mat-icon>
+        </a>
+        <a class="role r-loc" routerLink="/registrar-local">
+          <span class="ri"><mat-icon>store</mat-icon></span>
+          <div class="role-text">
+            <b>Local adherido</b>
+            <span>Canjeá cupones</span>
+          </div>
+          <mat-icon class="arr">chevron_right</mat-icon>
+        </a>
       </div>
-      <mat-icon class="arr">chevron_right</mat-icon>
-    </a>
-    <a class="role r-loc" routerLink="/registrar-local">
-      <span class="ri"><mat-icon>store</mat-icon></span>
-      <div class="role-text">
-        <b>Local adherido</b>
-        <span>Canjeá cupones</span>
-      </div>
-      <mat-icon class="arr">chevron_right</mat-icon>
-    </a>
+    </div>
+
+    <div class="login-footer">
+      <a class="back-link" [routerLink]="'/login'">
+        <mat-icon>arrow_back</mat-icon> Volver al inicio
+      </a>
+    </div>
   </div>
-
-</app-bottom-sheet>
+</div>

--- a/src/app/components/register-role-selector/register-role-selector.component.scss
+++ b/src/app/components/register-role-selector/register-role-selector.component.scss
@@ -1,16 +1,12 @@
-// La mecánica del sheet (wrapper, clip, backdrop, panel) vive en app-bottom-sheet.
-// Acá solo el contenido proyectado — movido desde login.component.scss.
-
 .role-hint {
   font-size: 13px;
   color: var(--muted);
-  margin: 4px 20px 14px;
+  margin-bottom: 14px;
 }
 
 .roles {
   display: grid;
   gap: 10px;
-  padding: 4px 20px 20px;
 }
 
 .role {

--- a/src/app/components/register-role-selector/register-role-selector.component.spec.ts
+++ b/src/app/components/register-role-selector/register-role-selector.component.spec.ts
@@ -5,7 +5,6 @@ import { RegisterRoleSelectorComponent } from './register-role-selector.componen
 
 describe('RegisterRoleSelectorComponent', () => {
   let fixture: ComponentFixture<RegisterRoleSelectorComponent>
-  let component: RegisterRoleSelectorComponent
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -14,7 +13,6 @@ describe('RegisterRoleSelectorComponent', () => {
     })
 
     fixture = TestBed.createComponent(RegisterRoleSelectorComponent)
-    component = fixture.componentInstance
     fixture.detectChanges()
   })
 
@@ -39,15 +37,5 @@ describe('RegisterRoleSelectorComponent', () => {
   it('routes the local option to /registrar-local', () => {
     const local = fixture.debugElement.query(By.css('.role.r-loc'))
     expect(local.nativeElement.getAttribute('href')).toBe('/registrar-local')
-  })
-
-  it('open() opens the underlying bottom sheet', () => {
-    // No hay backdrop visible antes de abrir.
-    expect(fixture.nativeElement.querySelector('.sheet-wrapper.is-open')).toBeNull()
-
-    component.open()
-    fixture.detectChanges()
-
-    expect(fixture.nativeElement.querySelector('.sheet-wrapper.is-open')).not.toBeNull()
   })
 })

--- a/src/app/components/register-role-selector/register-role-selector.component.ts
+++ b/src/app/components/register-role-selector/register-role-selector.component.ts
@@ -1,19 +1,12 @@
-import { Component, viewChild } from '@angular/core'
+import { Component } from '@angular/core'
 import { MatIconModule } from '@angular/material/icon'
 import { RouterModule } from '@angular/router'
-import { BottomSheetComponent } from '../bottom-sheet/bottom-sheet.component'
 
 @Component({
   selector: 'app-register-role-selector',
   standalone: true,
-  imports: [MatIconModule, RouterModule, BottomSheetComponent],
+  imports: [MatIconModule, RouterModule],
   templateUrl: './register-role-selector.component.html',
   styleUrl: './register-role-selector.component.scss'
 })
-export class RegisterRoleSelectorComponent {
-  private readonly sheet = viewChild.required(BottomSheetComponent)
-
-  open(): void {
-    this.sheet().open()
-  }
-}
+export class RegisterRoleSelectorComponent {}

--- a/src/app/layouts/role-layout/role-layout.component.html
+++ b/src/app/layouts/role-layout/role-layout.component.html
@@ -36,6 +36,7 @@
       [userName]="userName"
       [userSubtitle]="userSubtitle"
       [userDetail]="userDetail"
+      [userPhoto]="userPhoto"
       (navigate)="onMenuNavigate($event)"
       (doLogout)="onMenuLogout()"
     />
@@ -50,6 +51,7 @@
       [userPhoto]="userPhoto"
       [profileRoute]="profileRoute"
       (navigateFullPage)="onOptionsFullPageNav($event)"
+      (photoChanged)="onPhotoChanged($event)"
     />
   }
 </div>

--- a/src/app/layouts/role-layout/role-layout.component.ts
+++ b/src/app/layouts/role-layout/role-layout.component.ts
@@ -182,6 +182,10 @@ export class RoleLayoutComponent implements OnInit, OnDestroy {
     this.router.navigateByUrl(route)
   }
 
+  onPhotoChanged(url: string): void {
+    this.userPhoto = url
+  }
+
   onMenuNavigate(route: string): void {
     this.router.navigateByUrl(route)
   }

--- a/src/app/pages/historial-responsable/historial-responsable.component.scss
+++ b/src/app/pages/historial-responsable/historial-responsable.component.scss
@@ -81,16 +81,17 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.75rem;
-  background: #fff;
-  border: 1px solid #e0e0e0;
-  border-left: 4px solid #4caf50;
-  border-radius: 6px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--r-card);
+  box-shadow: var(--sh-1);
   padding: 0.85rem 1rem;
   margin-bottom: 1.5rem;
 
   .global-filter-label {
     font-weight: 600;
-    color: #2e7d32;
+    color: var(--accent);
     margin-right: 0.5rem;
   }
 
@@ -99,37 +100,39 @@
     align-items: center;
     gap: 0.4rem;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--muted);
   }
 
   input[type='date'] {
     padding: 0.4rem 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
     font-size: 0.85rem;
+    background: var(--surface);
+    color: var(--ink);
   }
 }
 
 .filter-btn {
-  background: #4caf50;
+  background: var(--accent);
   color: #fff;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  padding: 0.5rem 1.1rem;
+  border-radius: var(--r-pill);
   cursor: pointer;
   font-weight: 600;
   font-size: 0.85rem;
 
   &:hover {
-    background: #43a047;
+    filter: brightness(0.92);
   }
 }
 
 .filter-btn-secondary {
-  background: #757575;
+  background: var(--muted);
 
   &:hover {
-    background: #616161;
+    filter: brightness(0.9);
   }
 }
 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -41,7 +41,6 @@
     <div id="acciones" class="mt-4">
       <div class="buttons-container d-flex justify-content-center">
         <button class="btn btn-primary-custom" [routerLink]="['/login']">Ingresar</button>
-        <button class="btn btn-ghost-custom" [routerLink]="['/login-admin']">Entidades</button>
       </div>
     </div>
   </div>

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -51,10 +51,8 @@
     </div>
 
     <div class="login-footer">
-      <p class="register-link" (click)="registerSelector?.open()">No tengo una cuenta</p>
+      <p class="register-link" [routerLink]="'/registrarme'">No tengo una cuenta</p>
     </div>
 
   </div>
 </div>
-
-<app-register-role-selector></app-register-role-selector>

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -163,14 +163,9 @@ describe('LoginComponent', () => {
   })
 
   describe('"No tengo una cuenta"', () => {
-    it('opens the register role selector', () => {
-      expect(component.registerSelector).toBeDefined()
-      const openSpy = spyOn(component.registerSelector!, 'open')
-
+    it('links to the register role selector screen', () => {
       const link = fixture.debugElement.query(By.css('.register-link'))
-      link.nativeElement.click()
-
-      expect(openSpy).toHaveBeenCalled()
+      expect(link.nativeElement.getAttribute('href')).toBe('/registrarme')
     })
   })
 })

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,5 +1,5 @@
 import { StorageService } from '../../services/storage/storage.service'
-import { Component, inject, Inject, ViewChild } from '@angular/core'
+import { Component, inject, Inject } from '@angular/core'
 
 import { MatButtonModule } from '@angular/material/button'
 import { MatIconModule } from '@angular/material/icon'
@@ -23,7 +23,6 @@ import { UnifiedLoginResponse } from '../../services/interfaces/login-response'
 import { Role } from '../../services/interfaces/role'
 import { RecaptchaModule, RecaptchaFormsModule } from 'ng-recaptcha'
 import { RECAPTCHA_SITE_KEY } from '../../config/api.config'
-import { RegisterRoleSelectorComponent } from '../../components/register-role-selector/register-role-selector.component'
 
 type Module = 'neighbor' | 'reward-partner' | 'responsible' | 'entity'
 
@@ -90,8 +89,7 @@ const ROLE_CONFIG: Record<Role, RoleConfig> = {
     RouterModule,
     CommonModule,
     RecaptchaModule,
-    RecaptchaFormsModule,
-    RegisterRoleSelectorComponent
+    RecaptchaFormsModule
   ],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss'
@@ -103,8 +101,6 @@ export class LoginComponent {
   hide = true
   recaptchaToken = ''
   recaptchaSiteKey: string
-
-  @ViewChild(RegisterRoleSelectorComponent) registerSelector?: RegisterRoleSelectorComponent
 
   form: FormGroup
 

--- a/src/app/pages/mis-reciclados/mis-reciclados.component.scss
+++ b/src/app/pages/mis-reciclados/mis-reciclados.component.scss
@@ -81,16 +81,17 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.75rem;
-  background: #fff;
-  border: 1px solid #e0e0e0;
-  border-left: 4px solid #4caf50;
-  border-radius: 6px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--r-card);
+  box-shadow: var(--sh-1);
   padding: 0.85rem 1rem;
   margin-bottom: 1.5rem;
 
   .global-filter-label {
     font-weight: 600;
-    color: #2e7d32;
+    color: var(--accent);
     margin-right: 0.5rem;
   }
 
@@ -99,37 +100,39 @@
     align-items: center;
     gap: 0.4rem;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--muted);
   }
 
   input[type='date'] {
     padding: 0.4rem 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
     font-size: 0.85rem;
+    background: var(--surface);
+    color: var(--ink);
   }
 }
 
 .filter-btn {
-  background: #4caf50;
+  background: var(--accent);
   color: #fff;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  padding: 0.5rem 1.1rem;
+  border-radius: var(--r-pill);
   cursor: pointer;
   font-weight: 600;
   font-size: 0.85rem;
 
   &:hover {
-    background: #43a047;
+    filter: brightness(0.92);
   }
 }
 
 .filter-btn-secondary {
-  background: #757575;
+  background: var(--muted);
 
   &:hover {
-    background: #616161;
+    filter: brightness(0.9);
   }
 }
 


### PR DESCRIPTION
Convierte register-role-selector en la ruta /registrarme con el mismo shell de login/forgot-password, saca el botón "Entidades" del home (login ya unificado), sincroniza la foto de perfil entre el sheet de opciones y el tabbar/menú mobile, y empareja el estilo de los filtros de historial-responsable y mis-reciclados con el resto de la app.