### PR TITLE
fix(landing): unificar header de notificaciones y pulir dashboards

### DIFF
--- a/src/app/components/page-header/page-header.component.html
+++ b/src/app/components/page-header/page-header.component.html
@@ -1,7 +1,12 @@
-<header class="page-header">
-  <div class="ph-brand">
-    <mat-icon>recycling</mat-icon>
-    <span>GreenBin</span>
+<header class="page-header" appScrollShadow>
+  <div class="ph-top-row">
+    <div class="ph-brand">
+      <mat-icon>recycling</mat-icon>
+      <span>GreenBin</span>
+    </div>
+    <div class="ph-actions">
+      <ng-content select="[phActions]"></ng-content>
+    </div>
   </div>
 
   @if (title) {

--- a/src/app/components/page-header/page-header.component.scss
+++ b/src/app/components/page-header/page-header.component.scss
@@ -8,14 +8,22 @@
   padding: 22px 20px 26px;
   user-select: none;
   -webkit-user-select: none;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 0 0 rgba(15, 23, 18, 0);
+  transition: box-shadow 200ms ease;
+
+  &.is-scrolled {
+    box-shadow: 0 4px 14px rgba(15, 23, 18, 0.18);
+  }
 }
 
-@media (max-width: 959px) {
-  .page-header {
-    position: sticky;
-    top: 0;
-    z-index: 20;
-  }
+.ph-top-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .ph-brand {
@@ -31,6 +39,16 @@
     font-size: 22px;
     width: 22px;
     height: 22px;
+  }
+}
+
+.ph-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &:empty {
+    display: none;
   }
 }
 

--- a/src/app/components/page-header/page-header.component.ts
+++ b/src/app/components/page-header/page-header.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core'
 import { MatIconModule } from '@angular/material/icon'
+import { ScrollShadowDirective } from '../../directives/scroll-shadow.directive'
 
 /**
  * Cabecera unificada (gradiente del rol) usada en todas las pantallas mobile.
@@ -13,7 +14,7 @@ import { MatIconModule } from '@angular/material/icon'
 @Component({
   selector: 'app-page-header',
   standalone: true,
-  imports: [MatIconModule],
+  imports: [MatIconModule, ScrollShadowDirective],
   templateUrl: './page-header.component.html',
   styleUrl: './page-header.component.scss'
 })

--- a/src/app/directives/scroll-shadow.directive.ts
+++ b/src/app/directives/scroll-shadow.directive.ts
@@ -1,0 +1,23 @@
+import { Directive, HostBinding, HostListener, PLATFORM_ID, inject } from '@angular/core'
+import { isPlatformBrowser } from '@angular/common'
+
+/**
+ * Agrega la clase `is-scrolled` al host cuando la página bajó unos pocos
+ * píxeles. Pensado para headers `position: sticky` que necesitan una sombra
+ * sutil solo mientras el contenido pasa por debajo, no en reposo arriba.
+ */
+@Directive({
+  selector: '[appScrollShadow]',
+  standalone: true
+})
+export class ScrollShadowDirective {
+  private readonly platformId = inject(PLATFORM_ID)
+
+  @HostBinding('class.is-scrolled') isScrolled = false
+
+  @HostListener('window:scroll')
+  onScroll(): void {
+    if (!isPlatformBrowser(this.platformId)) return
+    this.isScrolled = window.scrollY > 4
+  }
+}

--- a/src/app/pages/historial-responsable/historial-responsable.component.html
+++ b/src/app/pages/historial-responsable/historial-responsable.component.html
@@ -25,17 +25,17 @@
     } @else {
       <div class="summary-cards">
         <div class="summary-card">
-          <span class="las la-weight" style="font-size: 2rem; color: var(--accent);"></span>
+          <div class="stat-ic g"><span class="las la-weight"></span></div>
           <h2>{{ totalWeight | number:'1.1-1' }} kg</h2>
           <small>Total procesado</small>
         </div>
         <div class="summary-card">
-          <span class="las la-star" style="font-size: 2rem; color: #f59e0b;"></span>
+          <div class="stat-ic y"><span class="las la-star"></span></div>
           <h2>{{ totalPoints | number }}</h2>
           <small>Puntos otorgados</small>
         </div>
         <div class="summary-card">
-          <span class="las la-exchange-alt" style="font-size: 2rem; color: #3b82f6;"></span>
+          <div class="stat-ic b"><span class="las la-exchange-alt"></span></div>
           <h2>{{ totalTransactions }}</h2>
           <small>Entregas procesadas</small>
         </div>

--- a/src/app/pages/historial-responsable/historial-responsable.component.scss
+++ b/src/app/pages/historial-responsable/historial-responsable.component.scss
@@ -29,10 +29,38 @@
   box-shadow: var(--sh-1);
   text-align: center;
 
+  .stat-ic {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    margin: 0 auto;
+
+    .las {
+      font-size: 1.35rem;
+    }
+
+    &.g {
+      background: var(--accent-soft);
+      color: var(--accent);
+    }
+
+    &.y {
+      background: rgba(224, 160, 25, 0.15);
+      color: var(--warning);
+    }
+
+    &.b {
+      background: rgba(58, 119, 181, 0.13);
+      color: var(--info);
+    }
+  }
+
   h2 {
     font-size: 1.5rem;
     color: var(--ink);
-    margin: 0.4rem 0 0.2rem;
+    margin: 0.6rem 0 0.2rem;
     font-family: 'Sora', sans-serif;
   }
 

--- a/src/app/pages/home-local/home-local.component.html
+++ b/src/app/pages/home-local/home-local.component.html
@@ -1,5 +1,5 @@
 <div data-role="local" class="landing-drawer">
-  <div class="v-header">
+  <div class="v-header" appScrollShadow>
     <div class="v-topbar">
       <span class="v-brand">GreenBin</span>
       <span class="spacer"></span>

--- a/src/app/pages/home-local/home-local.component.scss
+++ b/src/app/pages/home-local/home-local.component.scss
@@ -10,6 +10,15 @@
   padding: 20px 20px 28px;
   user-select: none;
   -webkit-user-select: none;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 0 0 rgba(15, 23, 18, 0);
+  transition: box-shadow 200ms ease;
+
+  &.is-scrolled {
+    box-shadow: 0 4px 14px rgba(15, 23, 18, 0.18);
+  }
 }
 
 .v-topbar {
@@ -240,9 +249,6 @@
 @media (max-width: 959px) {
   .v-header {
     padding-top: 24px;
-    position: sticky;
-    top: 0;
-    z-index: 20;
   }
 }
 

--- a/src/app/pages/home-local/home-local.component.ts
+++ b/src/app/pages/home-local/home-local.component.ts
@@ -14,6 +14,7 @@ import { LocalAdheridoService } from '../../services/local-adherido/local-adheri
 import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
 import { NotificationBellComponent } from '../../components/notification-bell/notification-bell.component'
 import { NotificationPanelComponent } from '../../components/notification-panel/notification-panel.component'
+import { ScrollShadowDirective } from '../../directives/scroll-shadow.directive'
 
 export type EstadoCuponFiltro = 'TODOS' | 'ADQUIRIDO' | 'USADO' | 'EXPIRADO'
 
@@ -34,7 +35,8 @@ export type EstadoCuponFiltro = 'TODOS' | 'ADQUIRIDO' | 'USADO' | 'EXPIRADO'
     DatePipe,
     SkeletonComponent,
     NotificationBellComponent,
-    NotificationPanelComponent
+    NotificationPanelComponent,
+    ScrollShadowDirective
   ],
   templateUrl: './home-local.component.html',
   styleUrl: './home-local.component.scss'

--- a/src/app/pages/landing-responsable/landing-responsable.component.html
+++ b/src/app/pages/landing-responsable/landing-responsable.component.html
@@ -1,5 +1,5 @@
 <div data-role="responsable" class="landing-drawer">
-  <div class="v-header">
+  <div class="v-header" appScrollShadow>
     <div class="v-topbar">
       <span class="v-brand">GreenBin</span>
       <span class="spacer"></span>

--- a/src/app/pages/landing-responsable/landing-responsable.component.scss
+++ b/src/app/pages/landing-responsable/landing-responsable.component.scss
@@ -10,6 +10,15 @@
   padding: 20px 20px 28px;
   user-select: none;
   -webkit-user-select: none;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 0 0 rgba(15, 23, 18, 0);
+  transition: box-shadow 200ms ease;
+
+  &.is-scrolled {
+    box-shadow: 0 4px 14px rgba(15, 23, 18, 0.18);
+  }
 }
 
 .v-topbar {
@@ -143,9 +152,6 @@
 @media (max-width: 959px) {
   .v-header {
     padding-top: 24px;
-    position: sticky;
-    top: 0;
-    z-index: 20;
   }
 }
 

--- a/src/app/pages/landing-responsable/landing-responsable.component.ts
+++ b/src/app/pages/landing-responsable/landing-responsable.component.ts
@@ -19,6 +19,7 @@ import { CommonModule, DatePipe, isPlatformBrowser } from '@angular/common'
 import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
 import { NotificationBellComponent } from '../../components/notification-bell/notification-bell.component'
 import { NotificationPanelComponent } from '../../components/notification-panel/notification-panel.component'
+import { ScrollShadowDirective } from '../../directives/scroll-shadow.directive'
 
 @Component({
   selector: 'app-landing-responsable',
@@ -38,7 +39,8 @@ import { NotificationPanelComponent } from '../../components/notification-panel/
     DatePipe,
     SkeletonComponent,
     NotificationBellComponent,
-    NotificationPanelComponent
+    NotificationPanelComponent,
+    ScrollShadowDirective
   ],
   templateUrl: './landing-responsable.component.html',
   styleUrl: './landing-responsable.component.scss'

--- a/src/app/pages/landing-vecino/landing-vecino.component.html
+++ b/src/app/pages/landing-vecino/landing-vecino.component.html
@@ -1,10 +1,10 @@
 <div data-role="vecino" class="landing-drawer">
   <app-page-header [title]="'¡Hola, ' + name + '! 🎉'">
+    <app-notification-bell phActions #bell (opened)="panel.open()" />
     <div class="hdr-chip">
       <mat-icon>stars</mat-icon>
       <app-animated-number [value]="puntos()" /> pts acumulados
     </div>
-    <app-notification-bell #bell (opened)="panel.open()" />
   </app-page-header>
 
   <app-notification-panel #panel (closed)="bell.refresh()" />

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -52,6 +52,10 @@
 
     <div class="login-footer">
       <p class="register-link" [routerLink]="'/registrarme'">No tengo una cuenta</p>
+      <div class="home-link" [routerLink]="''">
+        <mat-icon>home</mat-icon>
+        <span>Ir al inicio</span>
+      </div>
     </div>
 
   </div>

--- a/src/app/pages/mis-reciclados/mis-reciclados.component.html
+++ b/src/app/pages/mis-reciclados/mis-reciclados.component.html
@@ -25,17 +25,17 @@
     } @else {
       <div class="summary-cards">
         <div class="summary-card">
-          <span class="las la-weight" style="font-size: 2rem; color: var(--accent);"></span>
+          <div class="stat-ic g"><span class="las la-weight"></span></div>
           <h2>{{ totalWeight | number:'1.1-1' }} kg</h2>
           <small>Total reciclado</small>
         </div>
         <div class="summary-card">
-          <span class="las la-star" style="font-size: 2rem; color: #f59e0b;"></span>
+          <div class="stat-ic y"><span class="las la-star"></span></div>
           <h2>{{ totalPoints | number }}</h2>
           <small>Puntos obtenidos</small>
         </div>
         <div class="summary-card">
-          <span class="las la-exchange-alt" style="font-size: 2rem; color: #3b82f6;"></span>
+          <div class="stat-ic b"><span class="las la-exchange-alt"></span></div>
           <h2>{{ totalTransactions }}</h2>
           <small>Entregas realizadas</small>
         </div>

--- a/src/app/pages/mis-reciclados/mis-reciclados.component.scss
+++ b/src/app/pages/mis-reciclados/mis-reciclados.component.scss
@@ -29,10 +29,38 @@
   box-shadow: var(--sh-1);
   text-align: center;
 
+  .stat-ic {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    margin: 0 auto;
+
+    .las {
+      font-size: 1.35rem;
+    }
+
+    &.g {
+      background: var(--accent-soft);
+      color: var(--accent);
+    }
+
+    &.y {
+      background: rgba(224, 160, 25, 0.15);
+      color: var(--warning);
+    }
+
+    &.b {
+      background: rgba(58, 119, 181, 0.13);
+      color: var(--info);
+    }
+  }
+
   h2 {
     font-size: 1.5rem;
     color: var(--ink);
-    margin: 0.4rem 0 0.2rem;
+    margin: 0.6rem 0 0.2rem;
     font-family: 'Sora', sans-serif;
   }
 


### PR DESCRIPTION
Agrega botón "Ir al inicio" al login, unifica la posición de la campana de notificaciones (slot phActions en app-page-header, misma posición que ya usaban local/responsable), hace fijo el header en todos los tamaños de pantalla con una sombra sutil al scrollear (ScrollShadowDirective reutilizable), y lleva el estilo de ícono en círculo de entidad-dashboard a las cards de resumen de historial-responsable y mis-reciclados.