### PR TITLE
feat(local): panel de ROI para locales adheridos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -315,6 +315,11 @@ export const routes: Routes = [
           import('./pages/consultar-locales/consultar-locales.component').then(m => m.ConsultarLocalesComponent)
       },
       {
+        path: 'consultar-locales/:id/roi',
+        loadComponent: () =>
+          import('./pages/estadisticas-local/estadisticas-local.component').then(m => m.EstadisticasLocalComponent)
+      },
+      {
         path: 'registrar-categoria',
         loadComponent: () =>
           import('./pages/registrar-categoria/registrar-categoria.component').then(m => m.RegistrarCategoriaComponent)

--- a/src/app/pages/consultar-locales/consultar-locales.component.html
+++ b/src/app/pages/consultar-locales/consultar-locales.component.html
@@ -1,3 +1,3 @@
 <div data-role="entidad">
-  <app-table [columns]="columns" [title]="title" [tableData]="locales" [loading]="loading"></app-table>
+  <app-table [columns]="columns" [title]="title" [tableData]="locales" [loading]="loading" (edit)="verRoi($event)" (delete)="toggleLocal($event)"></app-table>
 </div>

--- a/src/app/pages/consultar-locales/consultar-locales.component.ts
+++ b/src/app/pages/consultar-locales/consultar-locales.component.ts
@@ -31,9 +31,33 @@ export class ConsultarLocalesComponent implements OnInit {
       { key: 'address', label: 'Dirección' },
       { key: 'email', label: 'Email' },
       { key: 'phoneNumber', label: 'Teléfono' },
-      { key: 'isActive', label: 'Estado' }
+      { key: 'isActive', label: 'Estado' },
+      { key: 'actions', label: 'Acciones' }
     ]
     if (isPlatformBrowser(this.platformId)) this.listLocales()
+  }
+
+  verRoi(id: string) {
+    this.router.navigate(['/entidad/consultar-locales', id, 'roi'])
+  }
+
+  toggleLocal(id: string) {
+    const local = this.locales.find(l => l.id === id)
+    if (!local) return
+    const activar = local.isActive !== 'Habilitado'
+    const titulo = activar ? '¿Habilitar este local?' : '¿Deshabilitar este local?'
+
+    Swal.fire({
+      title: titulo,
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Confirmar',
+      cancelButtonText: 'Cancelar'
+    }).then(result => {
+      if (result.isConfirmed) {
+        this.localService.update({ isActive: activar }, id).subscribe(() => this.listLocales())
+      }
+    })
   }
 
   listLocales() {

--- a/src/app/pages/estadisticas-local/estadisticas-local.component.html
+++ b/src/app/pages/estadisticas-local/estadisticas-local.component.html
@@ -1,4 +1,4 @@
-<app-navbar [title]="'Estadísticas'" [route]="'/local'"></app-navbar>
+<app-navbar [title]="navTitle" [route]="navBackRoute"></app-navbar>
 
 <div class="container">
 
@@ -55,6 +55,49 @@
         <span class="kpi-label">Puntos generados</span>
       </div>
     </div>
+
+    <!-- ROI: valor de negocio, no solo cupones -->
+    <h3 class="section-title">Retorno para el local</h3>
+    <div class="kpi-grid">
+      <div class="kpi-card kpi-teal">
+        <mat-icon>groups</mat-icon>
+        <span class="kpi-value">{{ uniqueNeighbors }}</span>
+        <span class="kpi-label">Vecinos distintos</span>
+      </div>
+      <div class="kpi-card kpi-purple">
+        <mat-icon>person_add</mat-icon>
+        <span class="kpi-value">{{ newNeighbors }}</span>
+        <span class="kpi-label">Vecinos nuevos</span>
+      </div>
+      <div class="kpi-card kpi-blue">
+        <mat-icon>repeat</mat-icon>
+        <span class="kpi-value">{{ avgVisitsPerNeighbor | number:'1.1-1' }}</span>
+        <span class="kpi-label">Visitas por vecino</span>
+      </div>
+      <div class="kpi-card kpi-green">
+        <mat-icon>stars</mat-icon>
+        <span class="kpi-value">{{ totalPuntos | number }}</span>
+        <span class="kpi-label">Puntos gastados acá</span>
+      </div>
+    </div>
+
+    @if (byCoupon.length > 0) {
+      <div class="card roi-by-coupon">
+        <div class="card-head">
+          <h3>Por cupón</h3>
+          <div class="card-sub">Qué cupón trae más clientes nuevos</div>
+        </div>
+        @for (c of byCoupon; track c.couponId) {
+          <div class="rail-item">
+            <div class="r-body">
+              <b>{{ c.title }}</b>
+              <small>{{ c.redemptions }} canjes · {{ c.uniqueNeighbors }} vecinos</small>
+            </div>
+            <span class="r-val">{{ c.newNeighbors }} nuevos</span>
+          </div>
+        }
+      </div>
+    }
 
     <!-- Charts -->
     <div class="charts-grid">

--- a/src/app/pages/estadisticas-local/estadisticas-local.component.scss
+++ b/src/app/pages/estadisticas-local/estadisticas-local.component.scss
@@ -110,6 +110,8 @@
   &.kpi-green  { background: #388e3c; }
   &.kpi-red    { background: #d32f2f; }
   &.kpi-orange { background: #f57c00; }
+  &.kpi-teal   { background: #00897b; }
+  &.kpi-purple { background: #7b1fa2; }
 }
 
 .kpi-value {
@@ -123,6 +125,76 @@
   opacity: 0.9;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+
+.section-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ink);
+  font-family: 'Sora', sans-serif;
+  margin: 4px 0 10px;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--r-card);
+  box-shadow: var(--sh-1);
+  padding: 16px 18px;
+  margin-bottom: 20px;
+}
+
+.card-head {
+  margin-bottom: 10px;
+
+  h3 {
+    font-size: 15px;
+    font-family: 'Sora', sans-serif;
+    color: var(--ink);
+    margin: 0;
+  }
+
+  .card-sub {
+    color: var(--muted);
+    font-size: 12px;
+    margin-top: 2px;
+  }
+}
+
+.rail-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 0;
+  border-top: 1px solid var(--line);
+
+  &:first-of-type {
+    border-top: 0;
+  }
+
+  .r-body {
+    flex: 1;
+    min-width: 0;
+
+    b {
+      display: block;
+      font-size: 13.5px;
+      font-weight: 600;
+      color: var(--ink);
+    }
+
+    small {
+      color: var(--muted);
+      font-size: 11.5px;
+    }
+  }
+
+  .r-val {
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--accent-ink, #388e3c);
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
 }
 
 /* ── Charts ──────────────────────────────────── */

--- a/src/app/pages/estadisticas-local/estadisticas-local.component.ts
+++ b/src/app/pages/estadisticas-local/estadisticas-local.component.ts
@@ -2,7 +2,7 @@ import { StorageService } from '../../services/storage/storage.service'
 import { inject, Component, OnInit, PLATFORM_ID } from '@angular/core'
 import { CommonModule, isPlatformBrowser } from '@angular/common'
 import { FormsModule } from '@angular/forms'
-import { RouterModule } from '@angular/router'
+import { ActivatedRoute, RouterModule } from '@angular/router'
 import { MatIconModule } from '@angular/material/icon'
 import { NgChartsModule } from 'ng2-charts'
 import { Chart, registerables, ChartData, ChartOptions } from 'chart.js'
@@ -22,9 +22,15 @@ Chart.register(...registerables)
 export class EstadisticasLocalComponent implements OnInit {
   private storage = inject(StorageService)
   private platformId = inject(PLATFORM_ID)
+  private route = inject(ActivatedRoute)
   private rewardPartnerId = ''
   private allTransactions: any[] = []
   loading = true
+
+  /** true cuando entra por la ruta de entidad (viendo el ROI de un local ajeno). */
+  viewingAsEntity = false
+  navTitle = 'Estadísticas'
+  navBackRoute = '/local'
 
   dateFrom = ''
   dateTo = ''
@@ -35,6 +41,19 @@ export class EstadisticasLocalComponent implements OnInit {
   totalUsado = 0
   totalExpirado = 0
   totalPuntos = 0
+
+  // ROI: valor de negocio para el local (clientes, no solo cupones)
+  uniqueNeighbors = 0
+  newNeighbors = 0
+  avgVisitsPerNeighbor = 0
+  byCoupon: Array<{
+    couponId: string
+    title: string
+    redemptions: number
+    uniqueNeighbors: number
+    newNeighbors: number
+    pointsSpent: number
+  }> = []
 
   // Bar chart - status distribution
   barData: ChartData<'bar'> = {
@@ -72,8 +91,16 @@ export class EstadisticasLocalComponent implements OnInit {
   constructor(private localService: LocalAdheridoService) {}
 
   ngOnInit(): void {
-    const info = this.storage.getItem('usuarioInfo') || '{}'
-    this.rewardPartnerId = JSON.parse(info).id
+    const idFromRoute = this.route.snapshot.paramMap.get('id')
+    if (idFromRoute) {
+      this.rewardPartnerId = idFromRoute
+      this.viewingAsEntity = true
+      this.navTitle = 'Panel de ROI'
+      this.navBackRoute = '/entidad/consultar-locales'
+    } else {
+      const info = this.storage.getItem('usuarioInfo') || '{}'
+      this.rewardPartnerId = JSON.parse(info).id
+    }
     if (isPlatformBrowser(this.platformId)) this.loadData()
   }
 
@@ -153,5 +180,63 @@ export class EstadisticasLocalComponent implements OnInit {
         }
       ]
     }
+
+    this.buildRoi(transactions)
+  }
+
+  // ROI: la "primera visita" de cada vecino se calcula sobre TODO el
+  // histórico (this.allTransactions), no sobre el rango filtrado — si no,
+  // un vecino que ya había venido antes del filtro parecería "nuevo" al
+  // volver a canjear dentro del rango.
+  private buildRoi(transactions: any[]): void {
+    const usadosHistorico = this.allTransactions.filter(t => t.status === 'USADO' && t.redeemDate)
+    const firstVisitByNeighbor = new Map<string, number>()
+    for (const t of usadosHistorico) {
+      const neighborId = t.neighbor?.id
+      if (!neighborId) continue
+      const ts = new Date(t.redeemDate).getTime()
+      const current = firstVisitByNeighbor.get(neighborId)
+      if (current == null || ts < current) firstVisitByNeighbor.set(neighborId, ts)
+    }
+
+    const usados = transactions.filter(t => t.status === 'USADO' && t.redeemDate)
+    const isFirstVisit = (t: any): boolean =>
+      firstVisitByNeighbor.get(t.neighbor?.id) === new Date(t.redeemDate).getTime()
+
+    this.uniqueNeighbors = new Set(usados.map(t => t.neighbor?.id)).size
+    this.newNeighbors = usados.filter(isFirstVisit).length
+    this.avgVisitsPerNeighbor = this.uniqueNeighbors > 0 ? usados.length / this.uniqueNeighbors : 0
+
+    const byCouponMap = new Map<
+      string,
+      {
+        couponId: string
+        title: string
+        redemptions: number
+        neighbors: Set<string>
+        newNeighbors: number
+        pointsSpent: number
+      }
+    >()
+    for (const t of usados) {
+      const couponId = t.coupon?.id ?? 'sin-cupon'
+      const entry = byCouponMap.get(couponId) ?? {
+        couponId,
+        title: t.coupon?.title ?? 'Cupón eliminado',
+        redemptions: 0,
+        neighbors: new Set<string>(),
+        newNeighbors: 0,
+        pointsSpent: 0
+      }
+      entry.redemptions++
+      if (t.neighbor?.id) entry.neighbors.add(t.neighbor.id)
+      entry.pointsSpent += t.costInPoints ?? 0
+      if (isFirstVisit(t)) entry.newNeighbors++
+      byCouponMap.set(couponId, entry)
+    }
+
+    this.byCoupon = Array.from(byCouponMap.values())
+      .map(({ neighbors, ...rest }) => ({ ...rest, uniqueNeighbors: neighbors.size }))
+      .sort((a, b) => b.newNeighbors - a.newNeighbors)
   }
 }


### PR DESCRIPTION
Suma métricas de negocio a estadisticas-local (vecinos únicos, vecinos nuevos, frecuencia de visitas, puntos gastados y desglose por cupón), calculadas client-side sobre datos que ya trae GET /api/coupon-transaction/reward-partner/:id — no hace falta tocar el backend.

La entidad puede ver el ROI de cualquier local desde "Locales adheridos" (nueva ruta entidad/consultar-locales/:id/roi, reusa el mismo componente vía route param). De paso, como la tabla de consultar-locales no tenía ninguna acción cableada, se sumó también habilitar/deshabilitar un local (mismo patrón que ya usa mis-cupones-local) para no dejar el botón de eliminar sin función.