### PR TITLE
feat: top vecinos, duplicar cupón y resumen del mes

### DIFF
--- a/src/app/pages/landing-responsable/landing-responsable.component.html
+++ b/src/app/pages/landing-responsable/landing-responsable.component.html
@@ -23,6 +23,22 @@
   <app-notification-panel #panel (closed)="bell.refresh()" />
 
   <div class="v-body">
+      @if (topVecinos.length > 0) {
+        <div class="card top-vecinos">
+          <div class="card-head">
+            <h3>Top vecinos</h3>
+            <div class="card-sub">En tu punto verde</div>
+          </div>
+          @for (v of topVecinos; track v.neighborId; let i = $index) {
+            <div class="rail-item">
+              <div class="r-ic">{{ i + 1 }}</div>
+              <div class="r-body"><b>{{ v.firstname }} {{ v.lastname }}</b></div>
+              <span class="r-val">{{ v.totalWeight | number:'1.0-1' }} kg</span>
+            </div>
+          }
+        </div>
+      }
+
       <h4>Historial</h4>
 
       @if (loading) {

--- a/src/app/pages/landing-responsable/landing-responsable.component.scss
+++ b/src/app/pages/landing-responsable/landing-responsable.component.scss
@@ -86,6 +86,74 @@
   font-size: 14px;
 }
 
+.card {
+  background: var(--surface);
+  border-radius: var(--r-card);
+  box-shadow: var(--sh-1);
+  padding: 16px 18px;
+  margin-bottom: 18px;
+}
+
+.card-head {
+  margin-bottom: 10px;
+
+  h3 {
+    font-size: 15px;
+    font-family: 'Sora', sans-serif;
+    color: var(--ink);
+    margin: 0;
+  }
+
+  .card-sub {
+    color: var(--muted);
+    font-size: 12px;
+    margin-top: 2px;
+  }
+}
+
+.rail-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 0;
+  border-top: 1px solid var(--line);
+
+  &:first-of-type {
+    border-top: 0;
+  }
+
+  .r-ic {
+    width: 28px;
+    height: 28px;
+    border-radius: 9px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    font-size: 12.5px;
+    font-weight: 700;
+  }
+
+  .r-body {
+    flex: 1;
+    min-width: 0;
+
+    b {
+      font-size: 13.5px;
+      font-weight: 600;
+      color: var(--ink);
+    }
+  }
+
+  .r-val {
+    font-weight: 700;
+    font-size: 13px;
+    color: var(--accent-ink);
+    flex-shrink: 0;
+  }
+}
+
 .tx-item {
   display: flex;
   align-items: center;

--- a/src/app/pages/landing-responsable/landing-responsable.component.ts
+++ b/src/app/pages/landing-responsable/landing-responsable.component.ts
@@ -13,6 +13,7 @@ import { SesionService } from '../../services/sesion/sesion.service'
 import { SidenavComponent } from '../../components/sidenav/sidenav.component'
 import { PuntoVerdeService } from '../../services/punto-verde/punto-verde.service'
 import { WasteDeliveryService } from '../../services/WasteDelivery/waste-delivery.service'
+import { StatisticsService } from '../../services/statistics/statistics.service'
 import { PuntoVerde } from '../../services/interfaces/punto-verde'
 import Swal from 'sweetalert2'
 import { CommonModule, DatePipe, isPlatformBrowser } from '@angular/common'
@@ -57,12 +58,14 @@ export class LandingResponsableComponent implements OnInit {
   historialVisible: any[] = []
   mostrarTodo: boolean = false
   LIMITE = 5
+  topVecinos: any[] = []
 
   constructor(
     private router: Router,
     private sesionService: SesionService,
     private pvService: PuntoVerdeService,
-    private wasteDeliveryService: WasteDeliveryService
+    private wasteDeliveryService: WasteDeliveryService,
+    private statisticsService: StatisticsService
   ) {
     this.nombre = this.formatearNombre(this.sesionService.getFirstname())
     const entidadInfo = JSON.parse(this.storage.getItem('entidadInfo') || '{}')
@@ -93,6 +96,19 @@ export class LandingResponsableComponent implements OnInit {
       },
       error: () => (this.loading = false)
     })
+
+    this.loadTopVecinos()
+  }
+
+  private loadTopVecinos(): void {
+    if (!this.pvSelec) {
+      this.topVecinos = []
+      return
+    }
+    this.statisticsService.getNeighborRankingByGreenPoint(this.pvSelec).subscribe({
+      next: (resp: any) => (this.topVecinos = (resp.data || []).slice(0, 5)),
+      error: () => (this.topVecinos = [])
+    })
   }
 
   toggleHistorial() {
@@ -103,6 +119,7 @@ export class LandingResponsableComponent implements OnInit {
   onChange(event: any) {
     this.storage.setItem('puntoVerde', event.value)
     this.pvSelec = event.value
+    this.loadTopVecinos()
   }
 
   editResponsible() {

--- a/src/app/pages/landing-vecino/landing-vecino.component.html
+++ b/src/app/pages/landing-vecino/landing-vecino.component.html
@@ -10,6 +10,29 @@
   <app-notification-panel #panel (closed)="bell.refresh()" />
 
   <div class="v-body">
+      @if (mesEntregas > 0) {
+        <div class="month-summary">
+          <div class="ms-head">
+            <mat-icon>calendar_month</mat-icon>
+            <span>Este mes</span>
+          </div>
+          <div class="ms-stats">
+            <div class="ms-stat">
+              <div class="stat-ic g"><mat-icon>scale</mat-icon></div>
+              <div class="ms-stat-text"><b>{{ mesKg | number:'1.1-1' }} kg</b><small>Reciclado</small></div>
+            </div>
+            <div class="ms-stat">
+              <div class="stat-ic y"><mat-icon>star</mat-icon></div>
+              <div class="ms-stat-text"><b>{{ mesPuntos | number }}</b><small>Puntos ganados</small></div>
+            </div>
+            <div class="ms-stat">
+              <div class="stat-ic b"><mat-icon>swap_horiz</mat-icon></div>
+              <div class="ms-stat-text"><b>{{ mesEntregas }}</b><small>Entregas</small></div>
+            </div>
+          </div>
+        </div>
+      }
+
       <h4>Historial</h4>
 
       @if (loading) {

--- a/src/app/pages/landing-vecino/landing-vecino.component.scss
+++ b/src/app/pages/landing-vecino/landing-vecino.component.scss
@@ -24,6 +24,98 @@
   font-size: 14px;
 }
 
+.month-summary {
+  background: var(--surface);
+  border-radius: var(--r-card);
+  box-shadow: var(--sh-1);
+  padding: 14px 16px;
+  margin-bottom: 18px;
+}
+
+.ms-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--muted);
+  margin-bottom: 12px;
+
+  mat-icon {
+    font-size: 17px;
+    width: 17px;
+    height: 17px;
+    color: var(--accent);
+  }
+}
+
+.ms-stats {
+  display: flex;
+  gap: 14px;
+}
+
+.ms-stat {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+
+  .stat-ic {
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &.g {
+      background: var(--accent-soft);
+      color: var(--accent);
+    }
+
+    &.y {
+      background: rgba(224, 160, 25, 0.15);
+      color: var(--warning);
+    }
+
+    &.b {
+      background: rgba(58, 119, 181, 0.13);
+      color: var(--info);
+    }
+  }
+
+  .ms-stat-text {
+    min-width: 0;
+
+    b {
+      display: block;
+      font-size: 14px;
+      font-family: 'Sora', sans-serif;
+      color: var(--ink);
+      white-space: nowrap;
+    }
+
+    small {
+      color: var(--muted);
+      font-size: 10.5px;
+    }
+  }
+}
+
+@media (max-width: 420px) {
+  .ms-stats {
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
 .tx-item {
   display: flex;
   align-items: center;

--- a/src/app/pages/landing-vecino/landing-vecino.component.ts
+++ b/src/app/pages/landing-vecino/landing-vecino.component.ts
@@ -15,6 +15,7 @@ import { NotificationBellComponent } from '../../components/notification-bell/no
 import { NotificationPanelComponent } from '../../components/notification-panel/notification-panel.component'
 import { AnimatedNumberComponent } from '../../components/animated-number/animated-number.component'
 import { VecinoService } from '../../services/vecino/vecino.service'
+import { StatisticsService } from '../../services/statistics/statistics.service'
 import { SesionService } from '../../services/sesion/sesion.service'
 import { RealtimeService } from '../../services/notification/realtime.service'
 import { CommonModule, DatePipe, isPlatformBrowser } from '@angular/common'
@@ -58,9 +59,13 @@ export class LandingVecinoComponent implements OnInit {
   mostrarTodo: boolean = false
   LIMITE = 5
   isDesktop = false
+  mesKg = 0
+  mesPuntos = 0
+  mesEntregas = 0
 
   constructor(
     private vecinoServ: VecinoService,
+    private statisticsService: StatisticsService,
     private breakpointObserver: BreakpointObserver
   ) {
     const info = this.storage.getItem('usuarioInfo') || '{}'
@@ -110,6 +115,20 @@ export class LandingVecinoComponent implements OnInit {
         this.loading = false
       },
       error: () => (this.loading = false)
+    })
+
+    const primerDiaDelMes = new Date(new Date().getFullYear(), new Date().getMonth(), 1)
+    this.statisticsService.getNeighborDeliveries(this.id, primerDiaDelMes.toISOString()).subscribe({
+      next: (resp: any) => {
+        const deliveries = resp.data || []
+        this.mesEntregas = deliveries.length
+        this.mesPuntos = deliveries.reduce((sum: number, d: any) => sum + d.totalPoints, 0)
+        this.mesKg = deliveries.reduce(
+          (sum: number, d: any) => sum + d.details.reduce((s: number, det: any) => s + det.weight, 0),
+          0
+        )
+      },
+      error: () => {}
     })
 
     this.vecinoServ.getMyWasteTransactions(this.id).subscribe({

--- a/src/app/pages/mis-cupones-local/mis-cupones-local.component.html
+++ b/src/app/pages/mis-cupones-local/mis-cupones-local.component.html
@@ -55,6 +55,7 @@
           <div class="c-card-badge">{{ data.discount }}<span>%</span></div>
           <div class="c-card-actions">
             <button class="c-icon-btn" (click)="edit(data)"><mat-icon>edit</mat-icon></button>
+            <button class="c-icon-btn" [title]="'Duplicar cupón'" (click)="duplicar(data)"><mat-icon>content_copy</mat-icon></button>
             <button class="c-icon-btn" (click)="toggleDisponible(data)">
               <mat-icon>{{ data.isAvailable ? 'block' : 'check_circle' }}</mat-icon>
             </button>

--- a/src/app/pages/mis-cupones-local/mis-cupones-local.component.ts
+++ b/src/app/pages/mis-cupones-local/mis-cupones-local.component.ts
@@ -1,4 +1,5 @@
 import { Component, viewChild, inject, PLATFORM_ID } from '@angular/core'
+import { Router } from '@angular/router'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTableDataSource } from '@angular/material/table'
 import { PageHeaderComponent } from '../../components/page-header/page-header.component'
@@ -35,7 +36,8 @@ export class MisCuponesLocalComponent {
 
   constructor(
     private service: LocalAdheridoService,
-    private sesionService: SesionService
+    private sesionService: SesionService,
+    private router: Router
   ) {
     this.localId = this.sesionService.getUserId()
     if (isPlatformBrowser(this.platformId)) this.getItems()
@@ -73,6 +75,10 @@ export class MisCuponesLocalComponent {
   edit(cupon: Coupon) {
     this.cuponEnEdicion = cupon
     this.editSheet().open()
+  }
+
+  duplicar(cupon: Coupon) {
+    this.router.navigate(['/local/registrar-cupon'], { state: { coupon: cupon } })
   }
 
   onCuponGuardado() {

--- a/src/app/pages/registrar-cupon/registrar-cupon.component.ts
+++ b/src/app/pages/registrar-cupon/registrar-cupon.component.ts
@@ -28,6 +28,20 @@ export class RegistrarCuponComponent {
     diasVigente: ['', Validators.required]
   })
 
+  constructor() {
+    // Al duplicar un cupón desde "Mis cupones" llega precargado vía router state.
+    const coupon = this.router.getCurrentNavigation()?.extras?.state?.['coupon']
+    if (coupon) {
+      this.formGroup.patchValue({
+        titulo: `Copia de ${coupon.title}`,
+        description: coupon.description,
+        descuento: coupon.discount,
+        costo: coupon.costInPoints,
+        diasVigente: coupon.validDays
+      })
+    }
+  }
+
   registrarCupon() {
     if (this.formGroup.valid) {
       const info = this.storage.getItem('usuarioInfo') || '{}'

--- a/src/app/services/statistics/statistics.service.ts
+++ b/src/app/services/statistics/statistics.service.ts
@@ -45,4 +45,11 @@ export class StatisticsService {
     if (to) params = params.set('to', to)
     return this.http.get(`${this.url}/neighbor/${neighborId}/deliveries`, { params })
   }
+
+  getNeighborRankingByGreenPoint(greenPointId: string, from?: string, to?: string): Observable<any> {
+    let params = new HttpParams()
+    if (from) params = params.set('from', from)
+    if (to) params = params.set('to', to)
+    return this.http.get(`${this.url}/green-point/${greenPointId}/neighbor-ranking`, { params })
+  }
 }


### PR DESCRIPTION
- landing-responsable: card "Top vecinos" del punto verde actual, usando el nuevo endpoint de ranking de vecinos.
- mis-cupones-local: botón para duplicar un cupón, precarga el form de registrar-cupon vía router state.
- landing-vecino: card "Este mes" (kg, puntos, entregas) reusando getNeighborDeliveries con rango del mes en curso.