### PR TITLE
fix(landing-vecino): mostrar estado vacío en "Este mes"

### DIFF
--- a/src/app/pages/landing-vecino/landing-vecino.component.html
+++ b/src/app/pages/landing-vecino/landing-vecino.component.html
@@ -10,26 +10,30 @@
   <app-notification-panel #panel (closed)="bell.refresh()" />
 
   <div class="v-body">
-      @if (mesEntregas > 0) {
+      @if (!mesLoading) {
         <div class="month-summary">
           <div class="ms-head">
             <mat-icon>calendar_month</mat-icon>
             <span>Este mes</span>
           </div>
-          <div class="ms-stats">
-            <div class="ms-stat">
-              <div class="stat-ic g"><mat-icon>scale</mat-icon></div>
-              <div class="ms-stat-text"><b>{{ mesKg | number:'1.1-1' }} kg</b><small>Reciclado</small></div>
+          @if (mesEntregas > 0) {
+            <div class="ms-stats">
+              <div class="ms-stat">
+                <div class="stat-ic g"><mat-icon>scale</mat-icon></div>
+                <div class="ms-stat-text"><b>{{ mesKg | number:'1.1-1' }} kg</b><small>Reciclado</small></div>
+              </div>
+              <div class="ms-stat">
+                <div class="stat-ic y"><mat-icon>star</mat-icon></div>
+                <div class="ms-stat-text"><b>{{ mesPuntos | number }}</b><small>Puntos ganados</small></div>
+              </div>
+              <div class="ms-stat">
+                <div class="stat-ic b"><mat-icon>swap_horiz</mat-icon></div>
+                <div class="ms-stat-text"><b>{{ mesEntregas }}</b><small>Entregas</small></div>
+              </div>
             </div>
-            <div class="ms-stat">
-              <div class="stat-ic y"><mat-icon>star</mat-icon></div>
-              <div class="ms-stat-text"><b>{{ mesPuntos | number }}</b><small>Puntos ganados</small></div>
-            </div>
-            <div class="ms-stat">
-              <div class="stat-ic b"><mat-icon>swap_horiz</mat-icon></div>
-              <div class="ms-stat-text"><b>{{ mesEntregas }}</b><small>Entregas</small></div>
-            </div>
-          </div>
+          } @else {
+            <p class="ms-empty">Todavía no reciclaste nada este mes</p>
+          }
         </div>
       }
 

--- a/src/app/pages/landing-vecino/landing-vecino.component.scss
+++ b/src/app/pages/landing-vecino/landing-vecino.component.scss
@@ -49,6 +49,12 @@
   }
 }
 
+.ms-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
 .ms-stats {
   display: flex;
   gap: 14px;

--- a/src/app/pages/landing-vecino/landing-vecino.component.ts
+++ b/src/app/pages/landing-vecino/landing-vecino.component.ts
@@ -62,6 +62,7 @@ export class LandingVecinoComponent implements OnInit {
   mesKg = 0
   mesPuntos = 0
   mesEntregas = 0
+  mesLoading = true
 
   constructor(
     private vecinoServ: VecinoService,
@@ -127,8 +128,9 @@ export class LandingVecinoComponent implements OnInit {
           (sum: number, d: any) => sum + d.details.reduce((s: number, det: any) => s + det.weight, 0),
           0
         )
+        this.mesLoading = false
       },
-      error: () => {}
+      error: () => (this.mesLoading = false)
     })
 
     this.vecinoServ.getMyWasteTransactions(this.id).subscribe({


### PR DESCRIPTION
La card solo se renderizaba si mesEntregas > 0, así que un vecino sin actividad en el mes calendario en curso no veía nada — parecía que la feature no estaba. Ahora la card siempre aparece una vez resuelta la carga, con un mensaje cuando no hay entregas todavía.