### PR TITLE
perf(notification-bell): reemplazar polling por el canal SSE existente

### DIFF
--- a/src/app/components/notification-bell/notification-bell.component.ts
+++ b/src/app/components/notification-bell/notification-bell.component.ts
@@ -1,10 +1,10 @@
-import { Component, EventEmitter, OnDestroy, OnInit, Output, PLATFORM_ID, inject, signal } from '@angular/core'
+import { Component, DestroyRef, EventEmitter, OnInit, Output, PLATFORM_ID, inject, signal } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { isPlatformBrowser } from '@angular/common'
 import { MatBadgeModule } from '@angular/material/badge'
 import { MatIconModule } from '@angular/material/icon'
 import { NotificationService } from '../../services/notification/notification.service'
-
-const POLL_INTERVAL_MS = 30000
+import { RealtimeService } from '../../services/notification/realtime.service'
 
 @Component({
   selector: 'app-notification-bell',
@@ -13,12 +13,13 @@ const POLL_INTERVAL_MS = 30000
   templateUrl: './notification-bell.component.html',
   styleUrl: './notification-bell.component.scss'
 })
-export class NotificationBellComponent implements OnInit, OnDestroy {
+export class NotificationBellComponent implements OnInit {
   @Output() opened = new EventEmitter<void>()
 
   private readonly platformId = inject(PLATFORM_ID)
   private readonly notificationService = inject(NotificationService)
-  private pollHandle?: ReturnType<typeof setInterval>
+  private readonly realtimeService = inject(RealtimeService)
+  private readonly destroyRef = inject(DestroyRef)
 
   readonly unreadCount = signal(0)
 
@@ -26,11 +27,11 @@ export class NotificationBellComponent implements OnInit, OnDestroy {
     if (!isPlatformBrowser(this.platformId)) return
 
     this.refresh()
-    this.pollHandle = setInterval(() => this.refresh(), POLL_INTERVAL_MS)
-  }
-
-  ngOnDestroy(): void {
-    if (this.pollHandle != null) clearInterval(this.pollHandle)
+    // Cada evento que llega por este canal ya representa una notificación
+    // recién creada para este usuario (el dispatcher del backend persiste
+    // antes de emitir por SSE) — no hace falta pollear, solo refrescar
+    // el contador cuando algo nuevo llega.
+    this.realtimeService.events$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.refresh())
   }
 
   refresh(): void {


### PR DESCRIPTION
Cada instancia del bell (landing-vecino, landing-responsable, home-local) hacía GET /unread-count cada 30s por setInterval. El canal SSE de RealtimeService ya emite las 4 categorías de notificación (no solo POINTS_DELIVERED) apenas se crean — el dispatcher del backend persiste antes de emitir, así que basta con refrescar el contador cuando llega cualquier evento. Sin cambios de backend.