### PR TITLE
fix(notifications): bypass ngsw and stop retry loop on 401 in SSE stream

### DIFF
--- a/src/app/services/notification/realtime.service.ts
+++ b/src/app/services/notification/realtime.service.ts
@@ -54,10 +54,21 @@ export class RealtimeService {
       const response = await fetch(`${this.apiBase}/api/notifications/stream`, {
         headers: {
           Authorization: `Bearer ${this.sesionService.getAccessToken()}`,
-          Accept: 'text/event-stream'
+          Accept: 'text/event-stream',
+          // El ngsw intercepta fetch() para su lógica de caché, y eso rompe
+          // una respuesta streaming (text/event-stream) que nunca termina.
+          'ngsw-bypass': 'true'
         },
         signal: this.abortController.signal
       })
+
+      if (response.status === 401) {
+        // Token inválido/expirado: reintentar no lo arregla, hace falta
+        // volver a autenticarse. Se corta el loop y el servicio queda listo
+        // para que un start() posterior (post-login) abra la conexión de nuevo.
+        this.abortController = null
+        return
+      }
 
       if (response.body == null) {
         this.scheduleReconnect()


### PR DESCRIPTION
El ServiceWorker de Angular interceptaba el fetch() del stream de notificaciones y rompia la respuesta streaming, ademas de que el servicio reintentaba cada 5s indefinidamente incluso con un 401 (token invalido/expirado), machacando al backend sin necesidad.