### PR TITLE
fix(registro): quitar log de debug y agregar validacion visual de pas…

### DIFF
--- a/src/app/components/password-requirements/password-requirements.component.html
+++ b/src/app/components/password-requirements/password-requirements.component.html
@@ -1,0 +1,6 @@
+<ul class="password-requirements">
+  <li *ngFor="let req of requirements" [class.met]="req.test(password)">
+    <mat-icon>{{ req.test(password) ? 'check_circle' : 'radio_button_unchecked' }}</mat-icon>
+    <span>{{ req.label }}</span>
+  </li>
+</ul>

--- a/src/app/components/password-requirements/password-requirements.component.scss
+++ b/src/app/components/password-requirements/password-requirements.component.scss
@@ -1,0 +1,27 @@
+.password-requirements {
+  list-style: none;
+  margin: 4px 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    color: #c62828;
+    transition: color 0.15s ease;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &.met {
+      color: #2e7d32;
+    }
+  }
+}

--- a/src/app/components/password-requirements/password-requirements.component.ts
+++ b/src/app/components/password-requirements/password-requirements.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { MatIconModule } from '@angular/material/icon'
+
+export interface PasswordRequirement {
+  label: string
+  test: (value: string) => boolean
+}
+
+@Component({
+  selector: 'app-password-requirements',
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
+  templateUrl: './password-requirements.component.html',
+  styleUrl: './password-requirements.component.scss'
+})
+export class PasswordRequirementsComponent {
+  @Input() password = ''
+  @Input() requirements: PasswordRequirement[] = []
+}

--- a/src/app/pages/registrar-local/registrar-local.component.html
+++ b/src/app/pages/registrar-local/registrar-local.component.html
@@ -103,10 +103,11 @@
           @if (formGroup.controls.password.hasError('required')) {
             <mat-error>Ingrese su contraseña.</mat-error>
           }
-          @if (formGroup.controls.password.hasError('pattern')) {
-            <mat-error>Ingrese una contraseña válida.</mat-error>
-          }
         </mat-form-field>
+        <app-password-requirements
+          [password]="formGroup.controls.password.value"
+          [requirements]="passwordRequirements">
+        </app-password-requirements>
 
         <mat-form-field>
           <mat-label>Confirmar Contraseña</mat-label>

--- a/src/app/pages/registrar-local/registrar-local.component.ts
+++ b/src/app/pages/registrar-local/registrar-local.component.ts
@@ -15,6 +15,10 @@ import { EntidadService } from '../../services/entidad/entidad.service'
 import { Entidad } from '../../services/interfaces/entidad'
 import { MatSelectModule } from '@angular/material/select'
 import { CommonModule } from '@angular/common'
+import {
+  PasswordRequirementsComponent,
+  PasswordRequirement
+} from '../../components/password-requirements/password-requirements.component'
 @Component({
   selector: 'app-registrar-local',
   standalone: true,
@@ -29,7 +33,8 @@ import { CommonModule } from '@angular/common'
     MapInputComponent,
     MatSelectModule,
     RouterModule,
-    CommonModule
+    CommonModule,
+    PasswordRequirementsComponent
   ],
   templateUrl: './registrar-local.component.html',
   styleUrl: './registrar-local.component.scss'
@@ -42,6 +47,11 @@ export class RegistrarLocalComponent implements OnInit {
   entitySelect = ''
   entities: Entidad[] = []
   disabled: boolean = true
+  passwordRequirements: PasswordRequirement[] = [
+    { label: 'Mínimo 8 caracteres', test: v => v.length >= 8 },
+    { label: 'Al menos una mayúscula', test: v => /[A-Z]/.test(v) },
+    { label: 'Al menos un carácter especial', test: v => /[!@#$%^&*()_+{}\[\]:;"'<>,.?/~`]/.test(v) }
+  ]
   @ViewChild(MapInputComponent) mapCompnent!: MapInputComponent
   constructor(
     private localService: LocalAdheridoService,

--- a/src/app/pages/registrar-vecino/registrar-vecino.component.html
+++ b/src/app/pages/registrar-vecino/registrar-vecino.component.html
@@ -68,23 +68,11 @@
           @if (form.get('password')!.hasError('required')) {
             <mat-error>Ingrese una contraseña</mat-error>
           }
-          @if (!form.get('password')!.hasError('required') && form.get('password')!.invalid) {
-            <mat-error>
-              @if (form.get('password')!.hasError('minlength')) {
-                <div>• Mínimo 8 caracteres</div>
-              }
-              @if (form.get('password')!.hasError('missingLowercase')) {
-                <div>• Al menos una minúscula</div>
-              }
-              @if (form.get('password')!.hasError('missingUppercase')) {
-                <div>• Al menos una mayúscula</div>
-              }
-              @if (form.get('password')!.hasError('missingSpecial')) {
-                <div>• Al menos un carácter especial</div>
-              }
-            </mat-error>
-          }
         </mat-form-field>
+        <app-password-requirements
+          [password]="form.get('password')!.value"
+          [requirements]="passwordRequirements">
+        </app-password-requirements>
 
         <mat-form-field>
           <mat-label>DNI</mat-label>

--- a/src/app/pages/registrar-vecino/registrar-vecino.component.ts
+++ b/src/app/pages/registrar-vecino/registrar-vecino.component.ts
@@ -22,6 +22,10 @@ import { CommonModule } from '@angular/common'
 import { StorageService } from '../../services/storage/storage.service'
 import { ThemeService } from '../../services/theme/theme.service'
 import Swal from 'sweetalert2'
+import {
+  PasswordRequirementsComponent,
+  PasswordRequirement
+} from '../../components/password-requirements/password-requirements.component'
 
 @Component({
   selector: 'app-registrar-vecino',
@@ -35,7 +39,8 @@ import Swal from 'sweetalert2'
     RouterModule,
     MatIconModule,
     MatSelectModule,
-    CommonModule
+    CommonModule,
+    PasswordRequirementsComponent
   ],
   templateUrl: './registrar-vecino.component.html',
   styleUrl: './registrar-vecino.component.scss'
@@ -44,6 +49,12 @@ export class RegistrarVecinoComponent implements OnInit {
   form: FormGroup
   hidePassword = true
   entities: Entidad[] = []
+  passwordRequirements: PasswordRequirement[] = [
+    { label: 'Mínimo 8 caracteres', test: v => v.length >= 8 },
+    { label: 'Al menos una minúscula', test: v => /[a-z]/.test(v) },
+    { label: 'Al menos una mayúscula', test: v => /[A-Z]/.test(v) },
+    { label: 'Al menos un carácter especial', test: v => /[!@#$%^&*()_+{}\[\]:;"'<>,.?/~`]/.test(v) }
+  ]
   constructor(
     private fb: FormBuilder,
     private vecinoService: VecinoService,
@@ -68,7 +79,6 @@ export class RegistrarVecinoComponent implements OnInit {
   ngOnInit(): void {
     this.entityServices.list(0, 100).subscribe((resp: any) => {
       this.entities = resp
-      console.log('Se listan las entidades \n', this.entities)
     })
   }
   passwordValidator(control: AbstractControl): ValidationErrors | null {


### PR DESCRIPTION
…sword

Se elimina el console.log de depuracion en registrar-vecino que quedaba visible en la consola del navegador al listar entidades.

Se agrega el componente password-requirements para mostrar en registrar-vecino y registrar-local que requisitos de contrasena cumple el usuario mientras escribe.