### PR TITLE
feat(catalogo-cupones): dejar de deducir el canje y consumir el del b…

### DIFF
--- a/src/app/components/cupon-sheet/cupon-sheet.component.ts
+++ b/src/app/components/cupon-sheet/cupon-sheet.component.ts
@@ -30,6 +30,13 @@ export class CuponSheetComponent {
   /** Emite los puntos restantes al canjear, para que el padre actualice el saldo. */
   @Output() cuponCanjeado = new EventEmitter<number>()
 
+  /**
+   * El backend rechazó el canje por una razón de negocio (ya lo tenías, el local
+   * lo borró, se quedó sin disponibilidad). El padre tiene que resincronizar el
+   * catálogo: lo que el vecino está viendo ya no refleja el estado real.
+   */
+  @Output() canjeRechazado = new EventEmitter<void>()
+
   cupon?: Coupon
   transaction?: any
   local?: LocalAdherido
@@ -101,7 +108,9 @@ export class CuponSheetComponent {
   }
 
   get puedeCanjear(): boolean {
-    return !!this.cupon && !this.cupon.adquirido && this.misPuntos >= this.cupon.costInPoints && !this.cargando
+    return (
+      !!this.cupon && this.cupon.redeemable !== false && this.misPuntos >= this.cupon.costInPoints && !this.cargando
+    )
   }
 
   // ── Acciones ───────────────────────────────────────────
@@ -132,7 +141,18 @@ export class CuponSheetComponent {
       },
       error: (err: any) => {
         this.cargando = false
-        alert('No se pudo canjear el cupón. ' + (err?.error?.message ?? 'Intentá de nuevo.'))
+
+        // El mensaje ya lo muestra requestInterceptor con el texto real del
+        // backend: un alert() acá le apilaba un segundo popup al vecino.
+        //
+        // Un 4xx es un rechazo de negocio, no una falla técnica: el catálogo
+        // está desactualizado y hay que resincronizarlo. Un 5xx o un corte de
+        // red no dicen nada del estado del cupón, así que no se toca la lista.
+        const status = err?.status ?? 0
+        if (status >= 400 && status < 500) {
+          this.canjeRechazado.emit()
+          this.cerrar()
+        }
       }
     })
   }

--- a/src/app/interceptors/request.interceptor.ts
+++ b/src/app/interceptors/request.interceptor.ts
@@ -114,9 +114,12 @@ export const requestInterceptor: HttpInterceptorFn = (req, next) => {
             cancelButton: 'btn btn-danger'
           }
         })
+        // El backend ya manda el motivo real en `message` (ej: "Ya canjeaste
+        // este cupón"). El texto de la ruta queda solo como fallback: pisarlo
+        // siempre hacía que el usuario leyera una causa que no era la suya.
         swalWithBootstrapButtons.fire({
           title: 'Ha ocurrido un error',
-          text: shouldNotify.errorMessage,
+          text: err?.error?.message ?? shouldNotify.errorMessage,
           icon: 'error'
         })
       }

--- a/src/app/pages/catalogo-cupones/catalogo-cupones.component.html
+++ b/src/app/pages/catalogo-cupones/catalogo-cupones.component.html
@@ -45,7 +45,7 @@
 
       <div class="c-list">
         @for (data of dataSource.filteredData; track data) {
-          <div class="c-card" [class.c-card-disabled]="data.adquirido" (click)="abrirModal(data)">
+          <div class="c-card" [class.c-card-disabled]="data.redeemable === false" (click)="abrirModal(data)">
             <div class="c-card-icon">
               <mat-icon>local_activity</mat-icon>
             </div>
@@ -55,8 +55,9 @@
               <div class="c-card-pills">
                 <span class="c-card-price">{{ data.costInPoints }} pts</span>
                 <span class="c-card-price c-card-vigencia">{{ data.validDays }} días</span>
-                @if (data.adquirido) {
-                  <span class="c-card-price c-card-adquirido">Ya canjeado</span>
+                <!-- El motivo lo decide la policy del backend, no esta pantalla. -->
+                @if (data.redeemable === false) {
+                  <span class="c-card-price c-card-adquirido">{{ data.reason }}</span>
                 }
               </div>
             </div>
@@ -68,5 +69,8 @@
 
   </div>
 
-  <app-cupon-sheet (cuponCanjeado)="onCuponCanjeado($event)"></app-cupon-sheet>
+  <app-cupon-sheet
+    (cuponCanjeado)="onCuponCanjeado($event)"
+    (canjeRechazado)="onCanjeRechazado()"
+  ></app-cupon-sheet>
 </div>

--- a/src/app/pages/catalogo-cupones/catalogo-cupones.component.ts
+++ b/src/app/pages/catalogo-cupones/catalogo-cupones.component.ts
@@ -11,7 +11,7 @@ import { VecinoService } from '../../services/vecino/vecino.service'
 import { RealtimeService } from '../../services/notification/realtime.service'
 import { Coupon, CampoOrdenCupon } from '../../services/interfaces/coupon'
 import { ordenarCupones } from '../../services/interfaces/coupon-sort.util'
-import { forkJoin, filter } from 'rxjs'
+import { filter } from 'rxjs'
 import { isPlatformBrowser } from '@angular/common'
 import { SkeletonComponent } from '../../components/skeleton/skeleton.component'
 import { NotificationBellComponent } from '../../components/notification-bell/notification-bell.component'
@@ -41,7 +41,6 @@ export class CatalogoCuponesComponent {
   dataSource: MatTableDataSource<any> = new MatTableDataSource()
   puntos = 0
   items: Coupon[] = []
-  redeemedCouponIds: Set<string> = new Set()
   titleFilter = ''
   sortField: CampoOrdenCupon = 'discount'
   sortDir: 'desc' | 'asc' = 'desc'
@@ -51,7 +50,7 @@ export class CatalogoCuponesComponent {
     const title = this.titleFilter.trim().toLowerCase()
     const filtered = this.items
       .filter(c => c.title.toLowerCase().includes(title))
-      .filter(c => !this.hideAdquiridos || !c.adquirido)
+      .filter(c => !this.hideAdquiridos || c.redeemable !== false)
     this.dataSource.data = ordenarCupones(filtered, this.sortField, this.sortDir)
   }
 
@@ -104,44 +103,26 @@ export class CatalogoCuponesComponent {
     const entityId = parsed?.entity?.id
     const neighborId = this.sesionService.getUserId()
 
-    const coupons$ = this.service.listCupon(entityId)
-    const myTransactions$ = neighborId ? this.vecinoService.getMyTransactions(neighborId) : null
+    // El catálogo del vecino ya llega resuelto contra la regla de canje. Sin
+    // vecino identificado no hay regla que aplicar, así que se cae al listado
+    // crudo de cupones disponibles.
+    const catalog$ = neighborId ? this.vecinoService.getCatalog(neighborId, entityId) : this.service.listCupon(entityId)
 
-    if (myTransactions$) {
-      forkJoin({ coupons: coupons$, transactions: myTransactions$ }).subscribe({
-        next: ({ coupons, transactions }) => {
-          // Solo bloqueamos re-canje mientras el cupón sigue ADQUIRIDO (activo y sin usar).
-          // Si ya fue USADO o quedó EXPIRADO, el vecino puede volver a comprarlo.
-          this.redeemedCouponIds = new Set(
-            (transactions.data ?? [])
-              .filter((t: any) => t.status === 'ADQUIRIDO')
-              .map((t: any) => t.coupon?.id ?? t.coupon)
-          )
-          this.items = (<Coupon[]>coupons.data).map(c => ({
-            ...c,
-            adquirido: this.redeemedCouponIds.has(c.id)
-          }))
-          this.dataSource = new MatTableDataSource(this.items)
-          this.applyFilters()
-          this.loading = false
-        },
-        error: () => (this.loading = false)
-      })
-    } else {
-      coupons$.subscribe({
-        next: obj => {
-          this.items = <Coupon[]>obj.data
-          this.dataSource = new MatTableDataSource(this.items)
-          this.applyFilters()
-          this.loading = false
-        },
-        error: () => (this.loading = false)
-      })
-    }
+    catalog$.subscribe({
+      next: obj => {
+        // El fallback sin vecino no trae `redeemable`: se normaliza acá para que
+        // la pantalla nunca tenga que preguntarse si el campo vino o no.
+        this.items = (<Coupon[]>obj.data).map(c => ({ ...c, redeemable: c.redeemable ?? true }))
+        this.dataSource = new MatTableDataSource(this.items)
+        this.applyFilters()
+        this.loading = false
+      },
+      error: () => (this.loading = false)
+    })
   }
 
   abrirModal(cupon: Coupon) {
-    if (cupon.adquirido) return
+    if (cupon.redeemable === false) return
     this.sheet?.openCatalog(cupon)
   }
 
@@ -153,6 +134,16 @@ export class CatalogoCuponesComponent {
 
   onCuponCanjeado(puntosRestantes: number) {
     this.puntos = puntosRestantes
+    this.getItems()
+  }
+
+  /**
+   * Race condition: el vecino tocó "Canjear" sobre un cupón que ya no podía
+   * canjear. En vez de adivinar el motivo en el cliente, se vuelve a pedir el
+   * estado al backend — que es la única fuente de verdad. El cupón queda en
+   * gris si ya lo tenía, o desaparece si el local lo borró.
+   */
+  onCanjeRechazado() {
     this.getItems()
   }
 }

--- a/src/app/services/interfaces/coupon.ts
+++ b/src/app/services/interfaces/coupon.ts
@@ -14,8 +14,14 @@ export interface Coupon {
   rewardPartner?: string
   rewardPartnerId?: string
   createdAt: string
-  /** Solo se completa en el catálogo del vecino: true si ya lo canjeó y sigue ADQUIRIDO sin usar. */
-  adquirido?: boolean
+  /**
+   * Solo en el catálogo del vecino: lo resuelve la policy de canje del backend.
+   * El front NO deduce la regla — la muestra. Si mañana el local puede
+   * configurar cuántas veces se canjea un cupón, esto no cambia.
+   */
+  redeemable?: boolean
+  /** Motivo por el que no se puede canjear, listo para mostrar (ej: "Ya canjeado"). */
+  reason?: string
 }
 
 export interface CouponTransaction {

--- a/src/app/services/vecino/vecino.service.ts
+++ b/src/app/services/vecino/vecino.service.ts
@@ -58,6 +58,16 @@ export class VecinoService {
     return this.http.get<any>(`${this.apiBase}/api/coupon-transaction/neighbor/${neighborId}`)
   }
 
+  /**
+   * Catálogo del vecino: los cupones ya vienen con `redeemable` y `reason`
+   * resueltos por el backend, así que la pantalla no tiene que cruzarlos contra
+   * sus transacciones para saber cuáles ya canjeó.
+   */
+  getCatalog(neighborId: string, entityId?: string): Observable<any> {
+    const url = `${this.apiBase}/api/coupon-transaction/catalog/${neighborId}`
+    return this.http.get<any>(entityId ? `${url}?entityId=${entityId}` : url)
+  }
+
   list(entityId?: string, includeInactive = false): Observable<any> {
     const token = this.storage.getItem('accessToken')
     const headers = new HttpHeaders({ Authorization: `Bearer ${token}` })


### PR DESCRIPTION
…ackend

El catálogo cruzaba cupones + transacciones propias del vecino con un forkJoin para armar a mano qué cupones ya estaban canjeados. Eso duplicaba en el front la misma regla que ya vive en el backend, y no tenía forma de reaccionar a nada que no fuera "yo ya lo canjeé" (cupón borrado por el local, sin puntos, etc).

Ahora se pide el catálogo ya resuelto (`redeemable` + `reason` por cupón) y la pantalla solo lo pinta: `adquirido` deja de existir en la interfaz Coupon.

Se cubre además la carrera de "el vecino toca Canjear sobre un cupón que dejó de poder canjear": cupon-sheet emite `canjeRechazado` ante cualquier 4xx y el catálogo refresca contra el backend, en vez de adivinar el motivo en el cliente. De paso se saca el alert() de cupon-sheet, que duplicaba el popup que ya dispara requestInterceptor
- y se corrige ese interceptor para mostrar el mensaje real del backend en vez de un texto fijo por ruta.